### PR TITLE
Add Events and Support Bundle download functionality

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -49,10 +49,25 @@
 
 ### SDK Helper Functions
 * [log](log.md)
+* [support_bundle](support_bundle.md)
+* [support_bundle_backlog](support_bundle_backlog.md)
+
+### Support Bundle Functions
+* [support_bundle](support_bundle.md)
+* [support_bundle_backlog](support_bundle_backlog.md)
 
 ### Internal Functions
 * [_api_validation](_api_validation.md)
 * [_authorization_header](_authorization_header.md)
+* [_db_a_event_id](_db_a_event_id.md)
+* [_db_d_event_id](_db_d_event_id.md)
+* [_db_q_backlog](_db_q_backlog.md)
+* [_db_q_event_id](_db_q_event_id.md)
+* [_db_u_bun_state](_db_u_bun_state.md)
+* [_db_u_job_state](_db_u_job_state.md)
+* [_download](_download.md)
+* [_generate](_generate.md)
 * [_header](_header.md)
+* [_status](_status.md)
 * [_common_api](_common_api.md)
 * [_date_time_conversion](_date_time_conversion.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -37,6 +37,9 @@
 * [vsphere_instant_recovery](vsphere_instant_recovery.md)
 * [vsphere_live_mount](vsphere_live_mount.md)
 
+### Event Functions
+* [get_events](get_events.md)
+
 ### Physical Host Functions
 * [add_physical_host](add_physical_host.md)
 * [assign_physical_host_fileset](assign_physical_host_fileset.md)

--- a/docs/_db_a_event_id.md
+++ b/docs/_db_a_event_id.md
@@ -1,0 +1,11 @@
+# _db_a_event_id
+
+Internal method to add a new EventID to the local internal database.
+```py
+def _db_a_event_id(data)
+```
+
+## Arguments
+| Name        | Type | Description                                                                 | Choices |
+|-------------|------|-----------------------------------------------------------------------------|---------|
+| data  | dict  | Dictionary containing event_id, job_id, job_state, expiry_time, status. |         |

--- a/docs/_db_d_event_id.md
+++ b/docs/_db_d_event_id.md
@@ -1,0 +1,11 @@
+# _db_d_event_id
+
+Internal method to delete an EventID from the local internal database due to `SUPPORT_BUNDLE_GENERATOR` job failure or age.
+```py
+def _db_d_event_id(event_id)
+```
+
+## Arguments
+| Name        | Type | Description                                                                 | Choices |
+|-------------|------|-----------------------------------------------------------------------------|---------|
+| event_id  | str  | EventID to remove from the database. |         |

--- a/docs/_db_q_backlog.md
+++ b/docs/_db_q_backlog.md
@@ -1,0 +1,12 @@
+# _db_q_backlog
+
+Internal method to query the local internal database for all existing EventIDs that have pending `SUPPORT_BUNDLE_GENERATOR` jobs.
+```py
+def _db_q_backlog()
+```
+
+
+## Returns
+| Type | Return Value                                                                                   |
+|------|-----------------------------------------------------------------------------------------------|
+| tuple  | The row(s) from the database containing EventIDs with `SUPPORT_BUNDLE_GENERATOR` jobs in a `GENERATING` status. |

--- a/docs/_db_q_event_id.md
+++ b/docs/_db_q_event_id.md
@@ -1,0 +1,16 @@
+# _db_q_event_id
+
+Internal method to query the local internal database for existing EventIDs so that duplicate generation jobs are not executed.
+```py
+def _db_q_event_id(event_id)
+```
+
+## Arguments
+| Name        | Type | Description                                                                 | Choices |
+|-------------|------|-----------------------------------------------------------------------------|---------|
+| event_id  | str  | The `eventSeriesId` returned by the `/internal/event` endpoint. |         |
+
+## Returns
+| Type | Return Value                                                                                   |
+|------|-----------------------------------------------------------------------------------------------|
+| tuple  | The row(s) from the database containing the EventID in question. |

--- a/docs/_db_u_bun_state.md
+++ b/docs/_db_u_bun_state.md
@@ -1,0 +1,12 @@
+# _db_u_bun_state
+
+Internal method to update the local internal database with the status of the Bundle.
+```py
+def _db_u_bun_state(job_id, bun_status)
+```
+
+## Arguments
+| Name        | Type | Description                                                                 | Choices |
+|-------------|------|-----------------------------------------------------------------------------|---------|
+| job_id  | str  | JobID of the `SUPPORT_BUNDLE_GENERATOR` job. |         |
+| bun_status  | str  | Status of the Bundle (`GENERATING` / `DOWNLOADED`). |         |

--- a/docs/_db_u_job_state.md
+++ b/docs/_db_u_job_state.md
@@ -1,0 +1,12 @@
+# _db_u_job_state
+
+Internal method to update the local internal database with the status of the `SUPPORT_BUNDLE_GENERATOR` job.
+```py
+def _db_u_job_state(job_id, job_state)
+```
+
+## Arguments
+| Name        | Type | Description                                                                 | Choices |
+|-------------|------|-----------------------------------------------------------------------------|---------|
+| job_id  | str  | JobID of the `SUPPORT_BUNDLE_GENERATOR` job. |         |
+| job_state  | str  | Status of the `SUPPORT_BUNDLE_GENERATOR` job as retrieved from the `/internal/support/support_bundle` endpoint. |         |

--- a/docs/_download.md
+++ b/docs/_download.md
@@ -1,0 +1,12 @@
+# _download
+
+Internal method to download the generated Support Bundle to your local machine.
+```py
+def _download(bundle_job, bundle_url)
+```
+
+## Arguments
+| Name        | Type | Description                                                                 | Choices |
+|-------------|------|-----------------------------------------------------------------------------|---------|
+| bundle_job  | str  | JobID of a `SUPPORT_BUNDLE_GENERATOR` job. |         |
+| bundle_url  | str  | URL to the generated Support Bundle as retrieved from the `/internal/support/support_bundle` API endpoint. |         |

--- a/docs/_generate.md
+++ b/docs/_generate.md
@@ -1,0 +1,11 @@
+# _generate
+
+Internal method to generate a Support Bundle for a given EventID.
+```py
+def _generate(event_id)
+```
+
+## Arguments
+| Name        | Type | Description                                                                 | Choices |
+|-------------|------|-----------------------------------------------------------------------------|---------|
+| event_id  | str  | The `eventSeriesId` returned by the `/internal/event` endpoint. |         |

--- a/docs/_status.md
+++ b/docs/_status.md
@@ -1,0 +1,16 @@
+# _status
+
+Internal method to retrieve the status of a `SUPPORT_BUNDLE_GENERATOR` job.
+```py
+def _status(bundle_job)
+```
+
+## Arguments
+| Name        | Type | Description                                                                 | Choices |
+|-------------|------|-----------------------------------------------------------------------------|---------|
+| bundle_job  | str  | JobID of a `SUPPORT_BUNDLE_GENERATOR` job. |         |
+
+## Returns
+| Type | Return Value                                                                                   |
+|------|-----------------------------------------------------------------------------------------------|
+| str  | The status of the `SUPPORT_BUNDLE_GENERATOR` job, or an error if the API was unable to find the JobID. |

--- a/docs/begin_managed_volume_snapshot.md
+++ b/docs/begin_managed_volume_snapshot.md
@@ -17,7 +17,7 @@ def begin_managed_volume_snapshot(name, timeout=30)
 ## Returns
 | Type | Return Value                                                                                   |
 |------|-----------------------------------------------------------------------------------------------|
-| str  | "No change required. The Managed Volume '`name`' is already assigned in a writeable state." |
+| str  | No change required. The Managed Volume '`name`' is already assigned in a writeable state. |
 | dict  | The full response for `POST /managed_volume/{id}/begin_snapshot`. |
 ## Example
 ```py

--- a/docs/create_docs.py
+++ b/docs/create_docs.py
@@ -310,6 +310,15 @@ for function in event_functions:
     if function[0] is '_':
         event_functions.remove(function)
 
+support_bundle_search = inspect.getmembers(rubrik_cdm.support_bundle.SupportBundle, inspect.isfunction)
+support_bundle_functions = []
+for function in support_bundle_search:
+    if function[0] not in base_api_functions:
+        support_bundle_functions.append(function[0])
+for function in support_bundle_functions:
+    if function[0] is '_':
+        support_bundle_functions.remove(function)
+
 combined_function_list = base_api_functions + cluster_functions + \
     data_management_functions + physical_functions + cloud_functions + \
     event_functions
@@ -372,6 +381,11 @@ for function in physical_functions:
 
 markdown.write('\n### SDK Helper Functions\n')
 for function in connect_functions:
+    if function[0] is not '_':
+        markdown.write('* [{}]({}.md)\n'.format(function, function))
+
+markdown.write('\n### Support Bundle Functions\n')
+for function in support_bundle_functions:
     if function[0] is not '_':
         markdown.write('* [{}]({}.md)\n'.format(function, function))
 

--- a/docs/create_docs.py
+++ b/docs/create_docs.py
@@ -1,15 +1,9 @@
 import inspect
-# import rubrik_cdm
+import rubrik_cdm
 import os
 import sys
 import reprlib
 
-CUR_DIR = os.path.dirname(
-    os.path.abspath(inspect.getfile(inspect.currentframe()))
-)
-PAR_DIR = os.path.dirname(CUR_DIR)
-sys.path.insert(0, PAR_DIR)
-import rubrik_cdm
 
 def print_doc_string(doc_string, section):
 

--- a/docs/create_docs.py
+++ b/docs/create_docs.py
@@ -1,9 +1,15 @@
 import inspect
-import rubrik_cdm
+# import rubrik_cdm
 import os
 import sys
 import reprlib
 
+CUR_DIR = os.path.dirname(
+    os.path.abspath(inspect.getfile(inspect.currentframe()))
+)
+PAR_DIR = os.path.dirname(CUR_DIR)
+sys.path.insert(0, PAR_DIR)
+import rubrik_cdm
 
 def print_doc_string(doc_string, section):
 
@@ -301,9 +307,18 @@ for function in cloud_functions:
     if function[0] is '_':
         cloud_functions.remove(function)
 
+event_search = inspect.getmembers(rubrik_cdm.events.Events, inspect.isfunction)
+event_functions = []
+for function in event_search:
+    if function[0] not in base_api_functions:
+        event_functions.append(function[0])
+for function in event_functions:
+    if function[0] is '_':
+        event_functions.remove(function)
 
 combined_function_list = base_api_functions + cluster_functions + \
-    data_management_functions + physical_functions + cloud_functions
+    data_management_functions + physical_functions + cloud_functions + \
+    event_functions
 
 connect_functions_search = inspect.getmembers(rubrik_cdm.rubrik_cdm.Connect, inspect.isfunction)
 connect_functions = []
@@ -351,6 +366,10 @@ markdown.write('\n### Data Management Functions\n')
 for function in data_management_functions:
     if function[0] is not '_':
         markdown.write('* [{}]({}.md)\n'.format(function, function))
+
+markdown.write('\n### Event Functions\n')
+for function in event_functions:
+    markdown.write('* [{}]({}.md)\n'.format(function, function))
 
 markdown.write('\n### Physical Host Functions\n')
 for function in physical_functions:

--- a/docs/get_events.md
+++ b/docs/get_events.md
@@ -8,13 +8,13 @@ def get_events(limit=10, status=None, event_type=None, object_type=None, object_
 ## Keyword Arguments
 | Name        | Type | Description                                                                 | Choices | Default |
 |-------------|------|-----------------------------------------------------------------------------|---------|---------|
-| limit  | int  | The limit of Events to return. Accepted limit is between 1-15. (Default 10) |         |         |
-| status  | str  | Filter the events by Status (Choices: {Failure}, {Warning}, {Running}, {Success}, {Canceled}, {Canceling}) |         |         |
-| event_type  | str  | Filter the events by Event Type (Choices: {Archive}, {Audit}, {AuthDomain}, {Backup}, {CloudNativeSource}, {Configuration}, {Diagnostic}, {Instantiate}, {Maintenance}, {NutanixCluster}, {Recovery}, {Replication}, {StorageArray}, {System}, {Vcd}, {VCenter}) |         |         |
-| object_type  | str  | Filter the events by Object Type (Choices: {VmwareVm}, {Mssql}, {LinuxFileset}, {WindowsFileset}, {WindowsHost}, {LinuxHost}, {StorageArrayVolumeGroup}, {VolumeGroup}, {NutanixVm}, {AwsAccount}, {Ec2Instance}) |         |         |
-| object_name  | str  | Filter the events by Object Name (Can be the name of a VM, Host, Fileset, Mssql Database, etc) |         |         |
-| before_date  | datetime  | Only show events before specified date. (Ex. 2018-10-01) |         |         |
-| after_date  | datetime  | Only show events after specified date. (Ex. 2018-10-01) |         |         |
+| limit  | int  | The limit of Events to return.  |    1-15     |    10      |
+| status  | str  | Filter the events by Status.  |    Failure, Warning, Running, Success, Canceled, Canceling     |    None      |
+| event_type  | str  | Filter the events by Event Type.  |    Archive Audit, AuthDomain, Backup, CloudNativeSource, Configuration, Diagnostic, Instantiate, Maintenance, NutanixCluster, Recovery, Replication, StorageArray, System, Vcd, VCenter     |    None      |
+| object_type  | str  | Filter the events by Object Type.  |    VmwareVm, Mssql, LinuxFileset, WindowsFileset, WindowsHost, LinuxHost, StorageArrayVolumeGroup, VolumeGroup, NutanixVm, AwsAccount, Ec2Instance     |    None      |
+| object_name  | str  | Filter the events by Object Name.  |    Can be the name of a VM, Host, Fileset, Mssql Database, etc     |    None      |
+| before_date  | datetime  | Only show events before specified date.  |    E.g. 2018-10-01     |    None      |
+| after_date  | datetime  | Only show events after specified date.  |    E.g. 2018-10-01     |    None      |
 
 ## Returns
 | Type | Return Value                                                                                   |

--- a/docs/get_events.md
+++ b/docs/get_events.md
@@ -2,16 +2,19 @@
 
 Return a list of Events matching the specified criteria.
 ```py
-def get_events(limit=10, status="", event_type="")
+def get_events(limit=10, status=None, event_type=None, object_type=None, object_name=None, before_date=None, after_date=None)
 ```
 
-## Arguments
-| Name        | Type | Description                                                                 | Choices |
-|-------------|------|-----------------------------------------------------------------------------|---------|
-| limit (optional - defaults to 10)  | int  | The limit of Events to return. Accepted limit is between 1-15. |         |
-| status (optional)  | str  | Filter the events by Status (Choices: {Failure}, {Warning}, {Running}, {Success}, {Canceled}, {Canceling}) |         |
-| event_type (optional)  | str  | Filter the events by Event Type (Choices: {Archive}, {Audit}, {AuthDomain}, {Backup}, {CloudNativeSource}, {Configuration}, {Diagnostic}, {Instantiate}, {Maintenance}, {NutanixCluster}, {Recovery}, {Replication}, {StorageArray}, {System}, {Vcd}, {VCenter}) |         |
-| object_type (optional)  | str  | Filter the events by Object Type (Choices: {VmwareVm}, {Mssql}, {LinuxFileset}, {WindowsFileset}, {WindowsHost}, {LinuxHost}, {StorageArrayVolumeGroup}, {VolumeGroup}, {NutanixVm}, {AwsAccount}, {Ec2Instance}) |         |
+## Keyword Arguments
+| Name        | Type | Description                                                                 | Choices | Default |
+|-------------|------|-----------------------------------------------------------------------------|---------|---------|
+| limit  | int  | The limit of Events to return. Accepted limit is between 1-15. (Default 10) |         |         |
+| status  | str  | Filter the events by Status (Choices: {Failure}, {Warning}, {Running}, {Success}, {Canceled}, {Canceling}) |         |         |
+| event_type  | str  | Filter the events by Event Type (Choices: {Archive}, {Audit}, {AuthDomain}, {Backup}, {CloudNativeSource}, {Configuration}, {Diagnostic}, {Instantiate}, {Maintenance}, {NutanixCluster}, {Recovery}, {Replication}, {StorageArray}, {System}, {Vcd}, {VCenter}) |         |         |
+| object_type  | str  | Filter the events by Object Type (Choices: {VmwareVm}, {Mssql}, {LinuxFileset}, {WindowsFileset}, {WindowsHost}, {LinuxHost}, {StorageArrayVolumeGroup}, {VolumeGroup}, {NutanixVm}, {AwsAccount}, {Ec2Instance}) |         |         |
+| object_name  | str  | Filter the events by Object Name (Can be the name of a VM, Host, Fileset, Mssql Database, etc) |         |         |
+| before_date  | datetime  | Only show events before specified date. (Ex. 2018-10-01) |         |         |
+| after_date  | datetime  | Only show events after specified date. (Ex. 2018-10-01) |         |         |
 
 ## Returns
 | Type | Return Value                                                                                   |

--- a/docs/get_events.md
+++ b/docs/get_events.md
@@ -1,0 +1,27 @@
+# get_events
+
+Return a list of Events matching the specified criteria.
+```py
+def get_events(limit=10, status="", event_type="")
+```
+
+## Arguments
+| Name        | Type | Description                                                                 | Choices |
+|-------------|------|-----------------------------------------------------------------------------|---------|
+| limit (optional - defaults to 10)  | int  | The limit of Events to return. Accepted limit is between 1-15. |         |
+| status (optional)  | str  | Filter the events by Status (Choices: {Failure}, {Warning}, {Running}, {Success}, {Canceled}, {Canceling}) |         |
+| event_type (optional)  | str  | Filter the events by Event Type (Choices: {Archive}, {Audit}, {AuthDomain}, {Backup}, {CloudNativeSource}, {Configuration}, {Diagnostic}, {Instantiate}, {Maintenance}, {NutanixCluster}, {Recovery}, {Replication}, {StorageArray}, {System}, {Vcd}, {VCenter}) |         |
+| object_type (optional)  | str  | Filter the events by Object Type (Choices: {VmwareVm}, {Mssql}, {LinuxFileset}, {WindowsFileset}, {WindowsHost}, {LinuxHost}, {StorageArrayVolumeGroup}, {VolumeGroup}, {NutanixVm}, {AwsAccount}, {Ec2Instance}) |         |
+
+## Returns
+| Type | Return Value                                                                                   |
+|------|-----------------------------------------------------------------------------------------------|
+| dict  | The `data` object within the API response for `GET /internal/event/` after applying the specified filters. |
+## Example
+```py
+import rubrik_cdm
+
+rubrik = rubrik_cdm.Connect()
+
+events = rubrik.get_events()
+```

--- a/docs/support_bundle.md
+++ b/docs/support_bundle.md
@@ -1,0 +1,26 @@
+# support_bundle
+
+Generate/Download a Support Bundle for the specified EventID(s).
+```py
+def support_bundle(event_id=None, events=None)
+```
+
+## Keyword Arguments
+| Name        | Type | Description                                                                 | Choices | Default |
+|-------------|------|-----------------------------------------------------------------------------|---------|---------|
+| event_id  | str  | EventID (`eventSeriesId`) to generate a Support Bundle for. |         |         |
+| events  | dict  | Dictionary of events returned by the `Events.get_events` method. |         |         |
+## Example
+```py
+import rubrik_cdm
+
+rubrik = rubrik_cdm.Connect()
+
+events = rubrik.get_events(
+    limit=10,
+    event_type="Backup",
+    status="Failure"
+)
+
+rubrik.support_bundle(events=events)
+```

--- a/docs/support_bundle_backlog.md
+++ b/docs/support_bundle_backlog.md
@@ -1,0 +1,15 @@
+# support_bundle_backlog
+
+Process all EventIDs with pending `SUPPORT_BUNDLE_GENERATOR` jobs.
+```py
+def support_bundle_backlog()
+```
+
+## Example
+```py
+import rubrik_cdm
+
+rubrik = rubrik_cdm.Connect()
+
+rubrik.support_bundle_backlog()
+```

--- a/rubrik_cdm/api.py
+++ b/rubrik_cdm/api.py
@@ -118,7 +118,7 @@ class Api():
             except NameError:
                 sys.exit(error)
             else:
-                sys.exit('Error: ' + error_message)
+                return error_message
         else:
             try:
                 return api_request.json()

--- a/rubrik_cdm/events.py
+++ b/rubrik_cdm/events.py
@@ -24,21 +24,24 @@ _API = Api
 class Events(_API):
     """This class contains methods related to Cluster/Object Events from the Rubrik Cluster."""
 
-    def get_events(self, limit=10, status="", event_type=""):
+    def get_events(self, limit=10, status=None, event_type=None, object_type=None, object_name=None, before_date=None, after_date=None):
         """Return a list of Events matching the specified criteria.
 
-        Arguments:
-            limit (optional - defaults to 10) {int} -- The limit of Events to return. Accepted limit is between 1-15.
-            status (optional) {str} -- Filter the events by Status (Choices: {Failure}, {Warning}, {Running}, {Success}, {Canceled}, {Canceling})
-            event_type (optional) {str} -- Filter the events by Event Type (Choices: {Archive}, {Audit}, {AuthDomain}, {Backup}, {CloudNativeSource}, {Configuration}, {Diagnostic}, {Instantiate}, {Maintenance}, {NutanixCluster}, {Recovery}, {Replication}, {StorageArray}, {System}, {Vcd}, {VCenter})
-            object_type (optional) {str} -- Filter the events by Object Type (Choices: {VmwareVm}, {Mssql}, {LinuxFileset}, {WindowsFileset}, {WindowsHost}, {LinuxHost}, {StorageArrayVolumeGroup}, {VolumeGroup}, {NutanixVm}, {AwsAccount}, {Ec2Instance})
+        Keyword Arguments:
+            limit {int} -- The limit of Events to return. Accepted limit is between 1-15. (Default 10)
+            status {str} -- Filter the events by Status (Choices: {Failure}, {Warning}, {Running}, {Success}, {Canceled}, {Canceling})
+            event_type {str} -- Filter the events by Event Type (Choices: {Archive}, {Audit}, {AuthDomain}, {Backup}, {CloudNativeSource}, {Configuration}, {Diagnostic}, {Instantiate}, {Maintenance}, {NutanixCluster}, {Recovery}, {Replication}, {StorageArray}, {System}, {Vcd}, {VCenter})
+            object_type {str} -- Filter the events by Object Type (Choices: {VmwareVm}, {Mssql}, {LinuxFileset}, {WindowsFileset}, {WindowsHost}, {LinuxHost}, {StorageArrayVolumeGroup}, {VolumeGroup}, {NutanixVm}, {AwsAccount}, {Ec2Instance})
+            object_name {str} -- Filter the events by Object Name (Can be the name of a VM, Host, Fileset, Mssql Database, etc)
+            before_date {datetime} -- Only show events before specified date. (Ex. 2018-10-01)
+            after_date {datetime} -- Only show events after specified date. (Ex. 2018-10-01)
 
         Returns:
             dict -- The `data` object within the API response for `GET /internal/event/` after applying the specified filters.
         """
         valid_limit = range(1, 16)
         valid_status = [
-            "",
+            None,
             "Failure",
             "Warning",
             "Running",
@@ -47,7 +50,7 @@ class Events(_API):
             "Canceling",
         ]
         valid_event_type = [
-            "",
+            None,
             "Archive",
             "Audit",
             "AuthDomain",
@@ -66,7 +69,7 @@ class Events(_API):
             "VCenter",
         ]
         valid_object_type = [
-            "",
+            None,
             "VmwareVm",
             "Mssql",
             "LinuxFileset",
@@ -113,9 +116,9 @@ class Events(_API):
         event_data["limit"] = limit
         event_data["status"] = status
         event_data["event_type"] = event_type
-        event_data["object_name"] = ""
-        event_data["before_date"] = ""
-        event_data["after_date"] = ""
+        event_data["object_name"] = object_name
+        event_data["before_date"] = before_date
+        event_data["after_date"] = after_date
         event_url = "/event?"
         for param in event_data:
             if event_data[param]:

--- a/rubrik_cdm/events.py
+++ b/rubrik_cdm/events.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 """
-This module contains the Rubrik SDK Data_Management class.
+This module contains the Rubrik SDK Event class.
 """
 
 import sys

--- a/rubrik_cdm/events.py
+++ b/rubrik_cdm/events.py
@@ -28,13 +28,13 @@ class Events(_API):
         """Return a list of Events matching the specified criteria.
 
         Keyword Arguments:
-            limit {int} -- The limit of Events to return. Accepted limit is between 1-15. (Default 10)
-            status {str} -- Filter the events by Status (Choices: {Failure}, {Warning}, {Running}, {Success}, {Canceled}, {Canceling})
-            event_type {str} -- Filter the events by Event Type (Choices: {Archive}, {Audit}, {AuthDomain}, {Backup}, {CloudNativeSource}, {Configuration}, {Diagnostic}, {Instantiate}, {Maintenance}, {NutanixCluster}, {Recovery}, {Replication}, {StorageArray}, {System}, {Vcd}, {VCenter})
-            object_type {str} -- Filter the events by Object Type (Choices: {VmwareVm}, {Mssql}, {LinuxFileset}, {WindowsFileset}, {WindowsHost}, {LinuxHost}, {StorageArrayVolumeGroup}, {VolumeGroup}, {NutanixVm}, {AwsAccount}, {Ec2Instance})
-            object_name {str} -- Filter the events by Object Name (Can be the name of a VM, Host, Fileset, Mssql Database, etc)
-            before_date {datetime} -- Only show events before specified date. (Ex. 2018-10-01)
-            after_date {datetime} -- Only show events after specified date. (Ex. 2018-10-01)
+            limit {int} -- The limit of Events to return. Accepted limit is between 1-15. (default: {'10'})
+            status {str} -- Filter the events by Status (choices: {Failure, Warning, Running, Success, Canceled, Canceling}) (default: {'None'})
+            event_type {str} -- Filter the events by Event Type (choices: {Archive Audit, AuthDomain, Backup, CloudNativeSource, Configuration, Diagnostic, Instantiate, Maintenance, NutanixCluster, Recovery, Replication, StorageArray, System, Vcd, VCenter}) (default: {'None'})
+            object_type {str} -- Filter the events by Object Type (choices: {VmwareVm, Mssql, LinuxFileset, WindowsFileset, WindowsHost, LinuxHost, StorageArrayVolumeGroup, VolumeGroup, NutanixVm, AwsAccount, Ec2Instance}) (default: {'None'})
+            object_name {str} -- Filter the events by Object Name (Can be the name of a VM, Host, Fileset, Mssql Database, etc) (default: {'None'})
+            before_date {datetime} -- Only show events before specified date. (Ex. 2018-10-01) (default: {'None'})
+            after_date {datetime} -- Only show events after specified date. (Ex. 2018-10-01) (default: {'None'})
 
         Returns:
             dict -- The `data` object within the API response for `GET /internal/event/` after applying the specified filters.

--- a/rubrik_cdm/events.py
+++ b/rubrik_cdm/events.py
@@ -1,0 +1,124 @@
+# Copyright 2018 Rubrik, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License prop
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module contains the Rubrik SDK Data_Management class.
+"""
+
+import sys
+from .api import Api
+
+_API = Api
+
+
+class Events(_API):
+    """This class contains methods related to Cluster/Object Events from the Rubrik Cluster."""
+
+    def get_events(self, limit=10, status="", event_type=""):
+        """Return a list of Events matching the specified criteria.
+
+        Arguments:
+            limit (optional - defaults to 10) {int} -- The limit of Events to return. Accepted limit is between 1-15.
+            status (optional) {str} -- Filter the events by Status (Choices: {Failure}, {Warning}, {Running}, {Success}, {Canceled}, {Canceling})
+            event_type (optional) {str} -- Filter the events by Event Type (Choices: {Archive}, {Audit}, {AuthDomain}, {Backup}, {CloudNativeSource}, {Configuration}, {Diagnostic}, {Instantiate}, {Maintenance}, {NutanixCluster}, {Recovery}, {Replication}, {StorageArray}, {System}, {Vcd}, {VCenter})
+            object_type (optional) {str} -- Filter the events by Object Type (Choices: {VmwareVm}, {Mssql}, {LinuxFileset}, {WindowsFileset}, {WindowsHost}, {LinuxHost}, {StorageArrayVolumeGroup}, {VolumeGroup}, {NutanixVm}, {AwsAccount}, {Ec2Instance})
+
+        Returns:
+            dict -- The `data` object within the API response for `GET /internal/event/` after applying the specified filters.
+        """
+        valid_limit = range(1, 16)
+        valid_status = [
+            "",
+            "Failure",
+            "Warning",
+            "Running",
+            "Success",
+            "Canceled",
+            "Canceling",
+        ]
+        valid_event_type = [
+            "",
+            "Archive",
+            "Audit",
+            "AuthDomain",
+            "Backup",
+            "CloudNativeSource",
+            "Configuration",
+            "Diagnostic",
+            "Instantiate",
+            "Maintenance",
+            "NutanixCluster",
+            "Recovery",
+            "Replication",
+            "StorageArray",
+            "System",
+            "Vcd",
+            "VCenter",
+        ]
+        valid_object_type = [
+            "",
+            "VmwareVm",
+            "Mssql",
+            "LinuxFileset",
+            "WindowsFileset",
+            "WindowsHost",
+            "LinuxHost",
+            "StorageArrayVolumeGroup",
+            "VolumeGroup",
+            "NutanixVm",
+            "AwsAccount",
+            "Ec2Instance",
+        ]
+
+        if limit not in valid_limit:
+            sys.exit(
+                "Error: Event Limit must be between {} and {}".format(
+                    valid_limit[0], len(valid_limit)
+                )
+            )
+
+        if status not in valid_status:
+            sys.exit(
+                "Error: Event Status must be one of the following - {}".format(
+                    valid_status
+                )
+            )
+
+        if event_type not in valid_event_type:
+            sys.exit(
+                "Error: Event Type must be one of the following - {}".format(
+                    valid_event_type
+                )
+            )
+
+        if object_type not in valid_object_type:
+            sys.exit(
+                "Error: Event Object must be one of the following - {}".format(
+                    valid_object_type
+                )
+            )
+
+        self.log("Querying the Rubrik API for the specified event criteria")
+        event_data = {}
+        event_data["limit"] = limit
+        event_data["status"] = status
+        event_data["event_type"] = event_type
+        event_data["object_name"] = ""
+        event_data["before_date"] = ""
+        event_data["after_date"] = ""
+        event_url = "/event?"
+        for param in event_data:
+            if event_data[param]:
+                event_url += "{}={}&".format(param, event_data[param])
+        api_request = self.get("internal", event_url)
+        return api_request["data"]

--- a/rubrik_cdm/events.py
+++ b/rubrik_cdm/events.py
@@ -28,13 +28,13 @@ class Events(_API):
         """Return a list of Events matching the specified criteria.
 
         Keyword Arguments:
-            limit {int} -- The limit of Events to return. Accepted limit is between 1-15. (default: {'10'})
-            status {str} -- Filter the events by Status (choices: {Failure, Warning, Running, Success, Canceled, Canceling}) (default: {'None'})
-            event_type {str} -- Filter the events by Event Type (choices: {Archive Audit, AuthDomain, Backup, CloudNativeSource, Configuration, Diagnostic, Instantiate, Maintenance, NutanixCluster, Recovery, Replication, StorageArray, System, Vcd, VCenter}) (default: {'None'})
-            object_type {str} -- Filter the events by Object Type (choices: {VmwareVm, Mssql, LinuxFileset, WindowsFileset, WindowsHost, LinuxHost, StorageArrayVolumeGroup, VolumeGroup, NutanixVm, AwsAccount, Ec2Instance}) (default: {'None'})
-            object_name {str} -- Filter the events by Object Name (Can be the name of a VM, Host, Fileset, Mssql Database, etc) (default: {'None'})
-            before_date {datetime} -- Only show events before specified date. (Ex. 2018-10-01) (default: {'None'})
-            after_date {datetime} -- Only show events after specified date. (Ex. 2018-10-01) (default: {'None'})
+            limit {int} -- The limit of Events to return. (default: {'10'}) (choices: {1-15})
+            status {str} -- Filter the events by Status. (default: {'None'}) (choices: {Failure, Warning, Running, Success, Canceled, Canceling})
+            event_type {str} -- Filter the events by Event Type. (default: {'None'}) (choices: {Archive Audit, AuthDomain, Backup, CloudNativeSource, Configuration, Diagnostic, Instantiate, Maintenance, NutanixCluster, Recovery, Replication, StorageArray, System, Vcd, VCenter})
+            object_type {str} -- Filter the events by Object Type. (default: {'None'}) (choices: {VmwareVm, Mssql, LinuxFileset, WindowsFileset, WindowsHost, LinuxHost, StorageArrayVolumeGroup, VolumeGroup, NutanixVm, AwsAccount, Ec2Instance})
+            object_name {str} -- Filter the events by Object Name. (default: {'None'}) (choices: {Can be the name of a VM, Host, Fileset, Mssql Database, etc}) 
+            before_date {datetime} -- Only show events before specified date. (default: {'None'}) (choices: {E.g. 2018-10-01})
+            after_date {datetime} -- Only show events after specified date. (default: {'None'}) (choices: {E.g. 2018-10-01})
 
         Returns:
             dict -- The `data` object within the API response for `GET /internal/event/` after applying the specified filters.

--- a/rubrik_cdm/rubrik_cdm.py
+++ b/rubrik_cdm/rubrik_cdm.py
@@ -28,6 +28,7 @@ from .cluster import Cluster
 from .data_management import Data_Management
 from .physical import Physical
 from .cloud import Cloud
+from .events import Events
 
 
 _CLUSTER = Cluster
@@ -35,9 +36,10 @@ _DATA_MANAGEMENT = Data_Management
 _PHYSICAL = Physical
 _API = Api
 _CLOUD = Cloud
+_EVENTS = Events
 
 
-class Connect(_CLUSTER, _DATA_MANAGEMENT, _PHYSICAL, _CLOUD):
+class Connect(_CLUSTER, _DATA_MANAGEMENT, _PHYSICAL, _CLOUD, _EVENTS):
     """This class acts as the base class for the Rubrik SDK and serves as the main interaction point
     for its end users. It also contains various helper functions used throughout the SDK.
 
@@ -45,6 +47,7 @@ class Connect(_CLUSTER, _DATA_MANAGEMENT, _PHYSICAL, _CLOUD):
         _CLUSTER {class} -- This class contains methods related to the managment of the Rubrik Cluster itself.
         _DATA_MANAGEMENT {class} - This class contains methods related to backup and restore operations for the various objects managed by the Rubrik Cluster.
         _PHYSICAL {class} - This class contains methods related to the managment of the Physical objects in the Rubrik Cluster.
+        _EVENTS {class} - This class contains methods related to Cluster/Object events.
     """
 
     def __init__(self, node_ip=None, username=None, password=None, enable_logging=False):

--- a/rubrik_cdm/support_bundle.py
+++ b/rubrik_cdm/support_bundle.py
@@ -54,8 +54,7 @@ class SupportBundle(_API):
 
         Arguments:
             job_id {str} -- JobID of the `SUPPORT_BUNDLE_GENERATOR` job.
-            bun_status {str} -- Status of the Bundle
-            (`GENERATING` / `DOWNLOADED`).
+            bun_status {str} -- Status of the Bundle (`GENERATING` / `DOWNLOADED`).
         """
         try:
             self.db_curs.execute(  # pylint: disable=no-member
@@ -73,8 +72,7 @@ class SupportBundle(_API):
 
         Arguments:
             job_id {str} -- JobID of the `SUPPORT_BUNDLE_GENERATOR` job.
-            job_state {str} -- Status of the `SUPPORT_BUNDLE_GENERATOR` job as
-            retrieved from the `/internal/support/support_bundle` endpoint.
+            job_state {str} -- Status of the `SUPPORT_BUNDLE_GENERATOR` job as retrieved from the `/internal/support/support_bundle` endpoint.
         """
         try:
             self.db_curs.execute(  # pylint: disable=no-member

--- a/rubrik_cdm/support_bundle.py
+++ b/rubrik_cdm/support_bundle.py
@@ -1,0 +1,289 @@
+# Copyright 2018 Rubrik, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License prop
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module contains the Rubrik SDK SupportBundle class.
+"""
+
+import os
+import sys
+from datetime import timedelta
+import sqlite3
+import requests
+from dateutil import parser
+from .api import Api
+
+_API = Api
+
+
+class SupportBundle(_API):
+    """This Class contains methods related to the generation and download of
+    Support Bundles"""
+
+    def _db_q_event_id(self, event_id):
+        """Internal method to query the local internal database for existing EventIDs so that duplicate generation jobs are not executed.
+
+        Arguments:
+            event_id {str} -- The `eventSeriesId` returned by the `/internal/event` endpoint.
+
+        Returns:
+            tuple -- The row(s) from the database containing the EventID in question.
+        """
+        try:
+            data = self.db_curs.execute(  # pylint: disable=no-member
+                """SELECT * FROM support_bundle WHERE
+                event_id=?""",
+                (event_id,),
+            )
+            return data.fetchall()
+        except sqlite3.Error as err:
+            sys.exit("Error querying database - {}".format(err))
+
+    def _db_u_bun_state(self, job_id, bun_status):
+        """Internal method to update the local internal database with the status of the Bundle.
+
+        Arguments:
+            job_id {str} -- JobID of the `SUPPORT_BUNDLE_GENERATOR` job.
+            bun_status {str} -- Status of the Bundle
+            (`GENERATING` / `DOWNLOADED`).
+        """
+        try:
+            self.db_curs.execute(  # pylint: disable=no-member
+                """UPDATE support_bundle
+                SET status=?
+                WHERE job_id=?""",
+                (bun_status, job_id),
+            )
+            self.conn.commit()  # pylint: disable=no-member
+        except sqlite3.Error as err:
+            sys.exit("Error updating database - {}".format(err))
+
+    def _db_u_job_state(self, job_id, job_state):
+        """Internal method to update the local internal database with the status of the `SUPPORT_BUNDLE_GENERATOR` job.
+
+        Arguments:
+            job_id {str} -- JobID of the `SUPPORT_BUNDLE_GENERATOR` job.
+            job_state {str} -- Status of the `SUPPORT_BUNDLE_GENERATOR` job as
+            retrieved from the `/internal/support/support_bundle` endpoint.
+        """
+        try:
+            self.db_curs.execute(  # pylint: disable=no-member
+                """UPDATE support_bundle
+                SET job_state=?
+                WHERE job_id=?""",
+                (job_state, job_id),
+            )
+            self.conn.commit()  # pylint: disable=no-member
+        except sqlite3.Error as err:
+            sys.exit("Error updating database - {}".format(err))
+
+    def _db_a_event_id(self, data):
+        """Internal method to add a new EventID to the local internal database.
+
+        Arguments:
+            data {dict} -- Dictionary containing event_id, job_id, job_state, expiry_time, status.
+        """
+        try:
+            event_id = data["event_id"]
+            job_id = data["job_id"]
+            job_state = data["state"]
+            expiry_time = data["expiry_time"]
+            status = data["status"]
+            self.db_curs.execute(  # pylint: disable=no-member
+                """INSERT INTO support_bundle
+                (event_id, job_id, job_state, expiry_time, status)
+                VALUES (?, ?, ?, ?, ?)""",
+                (event_id, job_id, job_state, expiry_time, status),
+            )
+            self.conn.commit()  # pylint: disable=no-member
+        except sqlite3.Error as err:
+            sys.exit("Error adding row - {}".format(err))
+        except KeyError as err:
+            sys.exit("Error populating data - {}".format(err))
+
+    def _db_d_event_id(self, event_id):
+        """Internal method to delete an EventID from the local internal database due to `SUPPORT_BUNDLE_GENERATOR` job failure or age.
+
+        Arguments:
+            event_id {str} -- EventID to remove from the database.
+        """
+        try:
+            self.log(  # pylint: disable=no-member
+                "Deleting row for Event ID {}".format(event_id)
+            )
+            self.db_curs.execute(  # pylint: disable=no-member
+                """DELETE FROM support_bundle WHERE
+                event_id=?""",
+                (event_id,),
+            )
+            self.conn.commit()  # pylint: disable=no-member
+        except sqlite3.Error as err:
+            sys.exit("Error deleting row - {}".format(err))
+
+    def _db_q_backlog(self):
+        """Internal method to query the local internal database for all existing EventIDs that have pending `SUPPORT_BUNDLE_GENERATOR` jobs.
+
+        Returns:
+            tuple -- The row(s) from the database containing EventIDs with `SUPPORT_BUNDLE_GENERATOR` jobs in a `GENERATING` status.
+        """
+        try:
+            data = self.db_curs.execute(  # pylint: disable=no-member
+                """SELECT * FROM support_bundle WHERE
+                status=?""",
+                ("GENERATING",),
+            )
+            return data.fetchall()
+        except sqlite3.Error as err:
+            sys.exit("Error querying database - {}".format(err))
+
+    def _download(self, bundle_job, bundle_url):
+        """Internal method to download the generated Support Bundle to your local machine.
+
+        Arguments:
+            bundle_job {str} -- JobID of a `SUPPORT_BUNDLE_GENERATOR` job.
+            bundle_url {str} -- URL to the generated Support Bundle as retrieved from the `/internal/support/support_bundle` API endpoint.
+        """
+        home_dir = os.path.expanduser("~")
+        dl_dir = home_dir + "/Downloads/"
+        if bundle_url.find("/"):
+            file_name = bundle_url.rsplit("/", 1)[1]
+            dl_path = dl_dir + file_name
+            if not os.path.isfile(dl_path):
+                try:
+                    dl_req = requests.get(
+                        bundle_url, verify=False, allow_redirects=True
+                    )
+                    self.log(  # pylint: disable=no-member
+                        "Downloading to {}".format(dl_path)
+                    )
+                    open(dl_path, "wb").write(dl_req.content)
+                    self._db_u_bun_state(bundle_job, "DOWNLOADED")
+                except requests.exceptions.RequestException as err:
+                    self.log(  # pylint: disable=no-member
+                        "Error while downloading {} - {}".format(
+                            bundle_url, err
+                        )
+                    )
+            else:
+                self.log(  # pylint: disable=no-member
+                    "{} already exists".format(dl_path)
+                )
+                self._db_u_bun_state(bundle_job, "DOWNLOADED")
+
+    def _status(self, bundle_job):
+        """Internal method to retrieve the status of a `SUPPORT_BUNDLE_GENERATOR` job.
+
+        Arguments:
+            bundle_job {str} -- JobID of a `SUPPORT_BUNDLE_GENERATOR` job.
+
+        Returns:
+            str -- The status of the `SUPPORT_BUNDLE_GENERATOR` job, or an error if the API was unable to find the JobID.
+        """
+        api_data = self.get(
+            "internal", "/support/support_bundle?id={}".format(bundle_job)
+        )
+        if "Could not find JobInstance" not in api_data:
+            job_status = api_data["status"]
+            self.log(  # pylint: disable=no-member
+                "Job {} Status: {}".format(bundle_job, job_status)
+            )
+            self._db_u_job_state(bundle_job, job_status)
+            if job_status == "SUCCEEDED":
+                for data in api_data["links"]:
+                    if "rubrik_job" in data["href"]:
+                        bundle_url = data["href"]
+                        self._download(bundle_job, bundle_url)
+        else:
+            job_status = api_data
+        return job_status
+
+    def _generate(self, event_id):
+        """Internal method to generate a Support Bundle for a given EventID.
+
+        Arguments:
+            event_id {str} -- The `eventSeriesId` returned by the `/internal/event` endpoint.
+        """
+        check_event = self._db_q_event_id(event_id)
+        if check_event:
+            bun_status = check_event[0][-1]
+            if bun_status == "GENERATING":
+                self.log(  # pylint: disable=no-member
+                    "Support Bundle generation for {} is in progress".format(
+                        event_id
+                    )
+                )
+                job_status = self._status(check_event[0][1])
+                if job_status == "FAILED":
+                    self._db_d_event_id(event_id)
+                    self._generate(event_id)
+                elif "Could not find JobInstance" in job_status:
+                    self._db_d_event_id(event_id)
+                elif job_status != "SUCCEEDED":
+                    self.log(  # pylint: disable=no-member
+                        "Request for EventID {} {}".format(
+                            event_id, job_status
+                        )
+                    )
+        else:
+            self.log(  # pylint: disable=no-member
+                "Generating Support Bundle for EventID {}".format(event_id)
+            )
+            data = {"eventId": "{}".format(event_id)}
+            api_data = self.post("internal", "/support/support_bundle", data)
+            bundle_info = {}
+            start_time = parser.parse(api_data["startTime"])
+            expiry_time = start_time + timedelta(hours=24)
+            bundle_info["event_id"] = event_id
+            bundle_info["job_id"] = api_data["id"]
+            bundle_info["state"] = api_data["status"]
+            bundle_info["expiry_time"] = expiry_time.strftime(
+                "%Y-%m-%d %H:%M:%S"
+            )
+            bundle_info["status"] = "GENERATING"
+            self._db_a_event_id(bundle_info)
+
+    def support_bundle_backlog(self):
+        """Process all EventIDs with pending `SUPPORT_BUNDLE_GENERATOR` jobs.
+        """
+        events = self._db_q_backlog()
+        if events:
+            self.log(  # pylint: disable=no-member
+                "{} Bundles in backlog".format(len(events))
+            )
+            for event in events:
+                event_id = event[0]
+                job_id = event[1]
+                status = self._status(job_id)
+                if status == "FAILED":
+                    self._db_d_event_id(event_id)
+                    self._generate(event_id)
+        else:
+            self.log("0 Bundles in backlog")  # pylint: disable=no-member
+
+    def support_bundle(self, event_id=None, events=None):
+        """Generate/Download a Support Bundle for the specified EventID(s).
+
+        Keyword Arguments:
+            event_id {str} -- EventID (`eventSeriesId`) to generate a Support Bundle for.
+            events {dict} -- Dictionary of events returned by the `Events.get_events` method.
+        """
+        if events:
+            for event in events:
+                event_id = event["eventSeriesId"]
+                self._generate(event_id)
+        elif event_id:
+            self._generate(event_id)
+        else:
+            sys.exit(
+                "Provide event_id (str) or events (dict) to this method."
+            )

--- a/sample/get_events.py
+++ b/sample/get_events.py
@@ -1,0 +1,5 @@
+import rubrik_cdm
+
+rubrik = rubrik_cdm.Connect()
+
+events = rubrik.get_events()

--- a/sample/support_bundle.py
+++ b/sample/support_bundle.py
@@ -1,0 +1,11 @@
+import rubrik_cdm
+
+rubrik = rubrik_cdm.Connect()
+
+events = rubrik.get_events(
+    limit=10,
+    event_type="Backup",
+    status="Failure"
+)
+
+rubrik.support_bundle(events=events)

--- a/sample/support_bundle_backlog.py
+++ b/sample/support_bundle_backlog.py
@@ -1,0 +1,5 @@
+import rubrik_cdm
+
+rubrik = rubrik_cdm.Connect()
+
+rubrik.support_bundle_backlog()


### PR DESCRIPTION
Initial implementation of Support Bundle generation/download functionality. This also required an additional module to handle events.

### High Level
* The `events.py` module was added to interface with `/internal/event` API endpoint, providing valid filter selection. Event return is capped to 15 as to not prompt accidental mass-generation of Support Bundles.
* Based on which event filters are provided, a Support Bundle generation job is initiated for each Event ID that is passed to the `support_bundle` method. This can be passed with an individual Event ID string `event` or a dict returned from the `get_events` method.
* The `support_bundle_backlog` method will not retrieve new Events from the Cluster, but will query the internal sqlite3 database for any previously-requested Support Bundle generation requests to fetch an updated status and download the Support Bundle if available. If a failed Support Bundle generation job is detected, it will remove the entry from the internal database and request that a new Support Bundle be generated.
* User Home directory is automatically detected, and `.rubrik-sdk` directory is created to hold internal sqlite3 database (`rubrik-sdk.db`). This database is used to track event_ids, Support Bundle generation jobs/status so as to not create duplicate generation/download requests for the same event. Any failed Support Bundle generation jobs will be purged from the database during 
* Support Bundles will be downloaded to `~/Downloads`.
