### PR TITLE
Add correct syntax to "configure_" function examples

### DIFF
--- a/docs/configure_dns_servers.md
+++ b/docs/configure_dns_servers.md
@@ -26,5 +26,5 @@ import rubrik_cdm
 rubrik = rubrik_cdm.Connect()
 
 dns_server_ip = ["192.168.100.21", "192.168.100.22"]
-cluster_dns_servers = rubrik.cluster_dns_servers(dns_server_ip)
+cluster_dns_servers = rubrik.configure_dns_servers(dns_server_ip)
 ```

--- a/docs/configure_ntp.md
+++ b/docs/configure_ntp.md
@@ -1,6 +1,6 @@
 # configure_ntp
 
-Configure the Rubrik cluster timezone.
+Configure connection information for the NTP servers used by the Rubrik cluster for time synchronization.
 ```py
 def configure_ntp(ntp_server)
 ```
@@ -22,5 +22,5 @@ import rubrik_cdm
 rubrik = rubrik_cdm.Connect()
 
 ntp_servers = ["192.168.10.121", "192.168.10.122"]
-configure_ntp = rubrik.cluster_ntp(ntp_servers)
+configure_ntp = rubrik.configure_ntp(ntp_servers)
 ```

--- a/docs/configure_search_domain.md
+++ b/docs/configure_search_domain.md
@@ -26,5 +26,5 @@ import rubrik_cdm
 rubrik = rubrik_cdm.Connect()
 
 search_domains = ["python.lab", "go.lab"]
-cluster_search_domains = rubrik.cluster_search_domain(search_domains)
+cluster_search_domains = rubrik.configure_search_domain(search_domains)
 ```

--- a/docs/configure_smtp_settings.md
+++ b/docs/configure_smtp_settings.md
@@ -37,5 +37,6 @@ from_email = "python@sdk.com"
 smtp_username = "pythonuser"
 smtp_password = "pythonpass"
 
-smtp_settings = rubrik.cluster_smtp_settings(smtp_hostname, port, from_email, smtp_username, smtp_password)
+smtp_settings = rubrik.configure_smtp_settings(
+    smtp_hostname, port, from_email, smtp_username, smtp_password)
 ```

--- a/docs/configure_syslog.md
+++ b/docs/configure_syslog.md
@@ -1,6 +1,6 @@
 # configure_syslog
 
-Configure the Rubrik cluster syslog settings..
+Configure the Rubrik cluster syslog settings.
 ```py
 def configure_syslog(syslog_ip, protocol, port=514, timeout=15)
 ```
@@ -30,5 +30,5 @@ rubrik = rubrik_cdm.Connect()
 syslog_ip = "192.168.1.208"
 protocol = "UDP"
 
-syslog = rubrik.cluster_syslog(syslog_ip, protocol)
+syslog = rubrik.configure_syslog(syslog_ip, protocol)
 ```

--- a/docs/configure_timezone.md
+++ b/docs/configure_timezone.md
@@ -23,5 +23,5 @@ rubrik = rubrik_cdm.Connect()
 
 timezone = "America/Chicago"
 
-configure_timezone = rubrik.cluster_timezone(timezone)
+configure_timezone = rubrik.configure_timezone(timezone)
 ```

--- a/docs/configure_vlan.md
+++ b/docs/configure_vlan.md
@@ -35,11 +35,11 @@ ips = ["192.168.1.100", "192.168.1.101", "192.168.1.102",
        "192.168.1.103", "192.168.1.104", "192.168.1.105", "192.168.1.106", "192.168.1.107"]
 
 
-vlan = rubrik.cluster_vlan(vlan, netmask, ips)
+vlan = rubrik.configure_vlan(vlan, netmask, ips)
 
 # Dict with node_name:ip as it's key pairs.
 ips = {'RVM015S011553': '192.168.1.100', 'RVM015S011884': '192.168.1.101', 'RVM015S011922': '192.168.1.102', 'RVM016S006406': '192.168.1.103',
        'RVM01AS007435': '192.168.1.104', 'RVM01AS012299': '192.168.1.105', 'RVM01AS025280': '192.168.1.106', 'RVM01AS025323': '192.168.1.107'}
 
-vlan = rubrik.cluster_vlan(vlan, netmask, ips)
+vlan = rubrik.configure_vlan(vlan, netmask, ips)
 ```

--- a/sample/configure_dns_servers.py
+++ b/sample/configure_dns_servers.py
@@ -3,4 +3,4 @@ import rubrik_cdm
 rubrik = rubrik_cdm.Connect()
 
 dns_server_ip = ["192.168.100.21", "192.168.100.22"]
-cluster_dns_servers = rubrik.cluster_dns_servers(dns_server_ip)
+cluster_dns_servers = rubrik.configure_dns_servers(dns_server_ip)

--- a/sample/configure_ntp.py
+++ b/sample/configure_ntp.py
@@ -3,4 +3,4 @@ import rubrik_cdm
 rubrik = rubrik_cdm.Connect()
 
 ntp_servers = ["192.168.10.121", "192.168.10.122"]
-configure_ntp = rubrik.cluster_ntp(ntp_servers)
+configure_ntp = rubrik.configure_ntp(ntp_servers)

--- a/sample/configure_search_domain.py
+++ b/sample/configure_search_domain.py
@@ -3,4 +3,4 @@ import rubrik_cdm
 rubrik = rubrik_cdm.Connect()
 
 search_domains = ["python.lab", "go.lab"]
-cluster_search_domains = rubrik.cluster_search_domain(search_domains)
+cluster_search_domains = rubrik.configure_search_domain(search_domains)

--- a/sample/configure_smtp_settings.py
+++ b/sample/configure_smtp_settings.py
@@ -8,4 +8,5 @@ from_email = "python@sdk.com"
 smtp_username = "pythonuser"
 smtp_password = "pythonpass"
 
-smtp_settings = rubrik.cluster_smtp_settings(smtp_hostname, port, from_email, smtp_username, smtp_password)
+smtp_settings = rubrik.configure_smtp_settings(
+    smtp_hostname, port, from_email, smtp_username, smtp_password)

--- a/sample/configure_syslog.py
+++ b/sample/configure_syslog.py
@@ -5,4 +5,4 @@ rubrik = rubrik_cdm.Connect()
 syslog_ip = "192.168.1.208"
 protocol = "UDP"
 
-syslog = rubrik.cluster_syslog(syslog_ip, protocol)
+syslog = rubrik.configure_syslog(syslog_ip, protocol)

--- a/sample/configure_timezone.py
+++ b/sample/configure_timezone.py
@@ -4,4 +4,4 @@ rubrik = rubrik_cdm.Connect()
 
 timezone = "America/Chicago"
 
-configure_timezone = rubrik.cluster_timezone(timezone)
+configure_timezone = rubrik.configure_timezone(timezone)

--- a/sample/configure_vlan.py
+++ b/sample/configure_vlan.py
@@ -10,10 +10,10 @@ ips = ["192.168.1.100", "192.168.1.101", "192.168.1.102",
        "192.168.1.103", "192.168.1.104", "192.168.1.105", "192.168.1.106", "192.168.1.107"]
 
 
-vlan = rubrik.cluster_vlan(vlan, netmask, ips)
+vlan = rubrik.configure_vlan(vlan, netmask, ips)
 
 # Dict with node_name:ip as it's key pairs.
 ips = {'RVM015S011553': '192.168.1.100', 'RVM015S011884': '192.168.1.101', 'RVM015S011922': '192.168.1.102', 'RVM016S006406': '192.168.1.103',
        'RVM01AS007435': '192.168.1.104', 'RVM01AS012299': '192.168.1.105', 'RVM01AS025280': '192.168.1.106', 'RVM01AS025323': '192.168.1.107'}
 
-vlan = rubrik.cluster_vlan(vlan, netmask, ips)
+vlan = rubrik.configure_vlan(vlan, netmask, ips)


### PR DESCRIPTION
Fixes issue where the "configure_" functions showed "cluster_" in the examples.