### PR TITLE
Add ability to pass dictionary of URL parameters

### DIFF
--- a/docs/_common_api.md
+++ b/docs/_common_api.md
@@ -14,6 +14,7 @@ def _common_api(call_type, api_version, api_endpoint, config=None, job_status_ur
 ## Keyword Arguments
 | Name           | Type | Description                                                                                                  | Choices | Default |
 |----------------|------|--------------------------------------------------------------------------------------------------------------|---------|---------|
+| params         | dict | An optional dict containing variables in a key:value format to send with `GET` & `DELETE` API calls          |         | None    |
 | config         | dict | The specified data to send with `POST` and `PATCH` API calls.                                                |         | None    |
 | job_status_url | str  | The job status URL provided by a previous API call.                                                          |         | None    |
 | timeout        | int  | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. |         | 15      |

--- a/docs/delete.md
+++ b/docs/delete.md
@@ -13,6 +13,7 @@ def delete(api_version, api_endpoint, timeout=15, authentication=True)
 ## Keyword Arguments
 | Name           | Type | Description                                                                                                  | Choices | Default |
 |----------------|------|--------------------------------------------------------------------------------------------------------------|---------|---------|
+| params         | dict | An optional dict containing variables in a key:value format to send with `GET` & `DELETE` API calls          |         | None    |
 | timeout        | int  | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. |         | 15      |
 | authentication | bool | Flag that specifies whether or not to utilize authentication when making the API call.                       |         | True    |
 

--- a/docs/get.md
+++ b/docs/get.md
@@ -13,6 +13,7 @@ def get(api_version, api_endpoint, timeout=15, authentication=True)
 ## Keyword Arguments
 | Name           | Type | Description                                                                                                  | Choices | Default |
 |----------------|------|--------------------------------------------------------------------------------------------------------------|---------|---------|
+| params         | dict | An optional dict containing variables in a key:value format to send with `GET` & `DELETE` API calls          |         | None    |
 | timeout        | int  | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. |         | 15      |
 | authentication | bool | Flag that specifies whether or not to utilize authentication when making the API call.                       |         | True    |
 
@@ -30,4 +31,11 @@ rubrik = rubrik_cdm.Connect()
 sla_name = "Python SDK"
 
 sla_summary_information = rubrik.get('v1', '/sla_domain?name={}'.format(sla_name))
+
+# The same information but now using the optional params argument
+params = {
+    "name": "Python SDK"
+}
+
+sla_summary_information = rubrik.get('v1', '/sla_domain', params=params)
 ```

--- a/rubrik_cdm/api.py
+++ b/rubrik_cdm/api.py
@@ -41,7 +41,7 @@ class Api():
             api_endpoint {str} -- The endpoint of the Rubrik CDM API to call (ex. /cluster/me).
 
         Keyword Arguments:
-            api_vars {dict} -- An optional dict containing variables in a key:value format to send with `GET` API calls (default: {None})
+            api_vars {dict} -- An optional dict containing variables in a key:value format to send with `GET` & `DELETE` API calls (default: {None})
             config {dict} -- The specified data to send with `POST` and `PATCH` API calls. (default: {None})
             job_status_url {str} -- The job status URL provided by a previous API call. (default: {None})
             timeout {int} -- The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. (default: {15})
@@ -100,6 +100,8 @@ class Api():
             elif call_type == 'DELETE':
                 request_url = "https://{}/api/{}{}".format(
                     self.node_ip, api_version, api_endpoint)
+                if api_vars is not None:
+                    request_url = request_url + "?" + '&'.join("{}={}".format(key,val) for (key,val) in api_vars.items())
                 self.log('DELETE {}'.format(request_url))
                 api_request = requests.delete(
                     request_url, verify=False, headers=header, timeout=timeout)
@@ -153,7 +155,7 @@ class Api():
             api_endpoint {str} -- The endpoint of the Rubrik CDM API to call (ex. /cluster/me).
 
         Keyword Arguments:
-            api_vars {dict} -- An optional dict containing variables in a key:value format to send with `GET` API calls (default: {None})
+            api_vars {dict} -- An optional dict containing variables in a key:value format to send with `GET` & `DELETE` API calls (default: {None})
             timeout {int} -- The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. (default: {15})
             authentication {bool} -- Flag that specifies whether or not to utilize authentication when making the API call. (default: {True})
 
@@ -221,7 +223,7 @@ class Api():
             timeout=timeout,
             authentication=authentication)
 
-    def delete(self, api_version, api_endpoint, timeout=15, authentication=True):
+    def delete(self, api_version, api_endpoint, api_vars=None, timeout=15, authentication=True):
         """Send a DELETE request to the provided Rubrik API endpoint.
 
         Arguments:
@@ -229,6 +231,7 @@ class Api():
             api_endpoint {str} -- The endpoint of the Rubrik CDM API to call (ex. /cluster/me).
 
         Keyword Arguments:
+            api_vars {dict} -- An optional dict containing variables in a key:value format to send with `GET` & `DELETE` API calls (default: {None})
             timeout {int} -- The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. (default: {15})
             authentication {bool} -- Flag that specifies whether or not to utilize authentication when making the API call. (default: {True})
 
@@ -240,6 +243,7 @@ class Api():
             'DELETE',
             api_version,
             api_endpoint,
+            api_vars=api_vars,
             config=None,
             job_status_url=None,
             timeout=timeout,

--- a/rubrik_cdm/api.py
+++ b/rubrik_cdm/api.py
@@ -165,7 +165,7 @@ class Api():
             'GET',
             api_version,
             api_endpoint,
-            api_vars=None,
+            api_vars=api_vars,
             config=None,
             job_status_url=None,
             timeout=timeout,

--- a/rubrik_cdm/api.py
+++ b/rubrik_cdm/api.py
@@ -32,7 +32,7 @@ class Api():
     def __init__(self, node_ip):
         super().__init__(node_ip)
 
-    def _common_api(self, call_type, api_version, api_endpoint, params=None, config=None, job_status_url=None, timeout=15, authentication=True):
+    def _common_api(self, call_type, api_version, api_endpoint, config=None, job_status_url=None, timeout=15, authentication=True, params=None):
         """Internal method that consolidates the base API functions.
 
         Arguments:
@@ -147,7 +147,7 @@ class Api():
             except BaseException:
                 return {'status_code': api_request.status_code}
 
-    def get(self, api_version, api_endpoint, params=None, timeout=15, authentication=True):
+    def get(self, api_version, api_endpoint, timeout=15, authentication=True, params=None):
         """Send a GET request to the provided Rubrik API endpoint.
 
         Arguments:
@@ -167,11 +167,11 @@ class Api():
             'GET',
             api_version,
             api_endpoint,
-            params=params,
             config=None,
             job_status_url=None,
             timeout=timeout,
-            authentication=authentication)
+            authentication=authentication,
+            params=params)
 
     def post(self, api_version, api_endpoint, config, timeout=15, authentication=True):
         """Send a POST request to the provided Rubrik API endpoint.
@@ -223,7 +223,7 @@ class Api():
             timeout=timeout,
             authentication=authentication)
 
-    def delete(self, api_version, api_endpoint, params=None, timeout=15, authentication=True):
+    def delete(self, api_version, api_endpoint, timeout=15, authentication=True, params=None):
         """Send a DELETE request to the provided Rubrik API endpoint.
 
         Arguments:
@@ -243,11 +243,11 @@ class Api():
             'DELETE',
             api_version,
             api_endpoint,
-            params=params,
             config=None,
             job_status_url=None,
             timeout=timeout,
-            authentication=authentication)
+            authentication=authentication,
+            params=params)
 
     def job_status(self, url, wait_for_completion=True, timeout=15):
         """Certain Rubrik operations (on-demand snapshots, live mounts, etc.) may not complete instantaneously. In those cases we have

--- a/rubrik_cdm/api.py
+++ b/rubrik_cdm/api.py
@@ -32,7 +32,7 @@ class Api():
     def __init__(self, node_ip):
         super().__init__(node_ip)
 
-    def _common_api(self, call_type, api_version, api_endpoint, api_vars=None, config=None, job_status_url=None, timeout=15, authentication=True):
+    def _common_api(self, call_type, api_version, api_endpoint, params=None, config=None, job_status_url=None, timeout=15, authentication=True):
         """Internal method that consolidates the base API functions.
 
         Arguments:
@@ -41,7 +41,7 @@ class Api():
             api_endpoint {str} -- The endpoint of the Rubrik CDM API to call (ex. /cluster/me).
 
         Keyword Arguments:
-            api_vars {dict} -- An optional dict containing variables in a key:value format to send with `GET` & `DELETE` API calls (default: {None})
+            params {dict} -- An optional dict containing variables in a key:value format to send with `GET` & `DELETE` API calls (default: {None})
             config {dict} -- The specified data to send with `POST` and `PATCH` API calls. (default: {None})
             job_status_url {str} -- The job status URL provided by a previous API call. (default: {None})
             timeout {int} -- The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. (default: {15})
@@ -67,8 +67,8 @@ class Api():
             if call_type == 'GET':
                 request_url = "https://{}/api/{}{}".format(
                     self.node_ip, api_version, api_endpoint)
-                if api_vars is not None:
-                    request_url = request_url + "?" + '&'.join("{}={}".format(key,val) for (key,val) in api_vars.items())
+                if params is not None:
+                    request_url = request_url + "?" + '&'.join("{}={}".format(key,val) for (key,val) in params.items())
                 request_url = quote(request_url, '://?=&')
                 self.log('GET {}'.format(request_url))
                 api_request = requests.get(
@@ -100,8 +100,8 @@ class Api():
             elif call_type == 'DELETE':
                 request_url = "https://{}/api/{}{}".format(
                     self.node_ip, api_version, api_endpoint)
-                if api_vars is not None:
-                    request_url = request_url + "?" + '&'.join("{}={}".format(key,val) for (key,val) in api_vars.items())
+                if params is not None:
+                    request_url = request_url + "?" + '&'.join("{}={}".format(key,val) for (key,val) in params.items())
                 self.log('DELETE {}'.format(request_url))
                 api_request = requests.delete(
                     request_url, verify=False, headers=header, timeout=timeout)
@@ -147,7 +147,7 @@ class Api():
             except BaseException:
                 return {'status_code': api_request.status_code}
 
-    def get(self, api_version, api_endpoint, api_vars=None, timeout=15, authentication=True):
+    def get(self, api_version, api_endpoint, params=None, timeout=15, authentication=True):
         """Send a GET request to the provided Rubrik API endpoint.
 
         Arguments:
@@ -155,7 +155,7 @@ class Api():
             api_endpoint {str} -- The endpoint of the Rubrik CDM API to call (ex. /cluster/me).
 
         Keyword Arguments:
-            api_vars {dict} -- An optional dict containing variables in a key:value format to send with `GET` & `DELETE` API calls (default: {None})
+            params {dict} -- An optional dict containing variables in a key:value format to send with `GET` & `DELETE` API calls (default: {None})
             timeout {int} -- The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. (default: {15})
             authentication {bool} -- Flag that specifies whether or not to utilize authentication when making the API call. (default: {True})
 
@@ -167,7 +167,7 @@ class Api():
             'GET',
             api_version,
             api_endpoint,
-            api_vars=api_vars,
+            params=params,
             config=None,
             job_status_url=None,
             timeout=timeout,
@@ -223,7 +223,7 @@ class Api():
             timeout=timeout,
             authentication=authentication)
 
-    def delete(self, api_version, api_endpoint, api_vars=None, timeout=15, authentication=True):
+    def delete(self, api_version, api_endpoint, params=None, timeout=15, authentication=True):
         """Send a DELETE request to the provided Rubrik API endpoint.
 
         Arguments:
@@ -231,7 +231,7 @@ class Api():
             api_endpoint {str} -- The endpoint of the Rubrik CDM API to call (ex. /cluster/me).
 
         Keyword Arguments:
-            api_vars {dict} -- An optional dict containing variables in a key:value format to send with `GET` & `DELETE` API calls (default: {None})
+            params {dict} -- An optional dict containing variables in a key:value format to send with `GET` & `DELETE` API calls (default: {None})
             timeout {int} -- The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. (default: {15})
             authentication {bool} -- Flag that specifies whether or not to utilize authentication when making the API call. (default: {True})
 
@@ -243,7 +243,7 @@ class Api():
             'DELETE',
             api_version,
             api_endpoint,
-            api_vars=api_vars,
+            params=params,
             config=None,
             job_status_url=None,
             timeout=timeout,

--- a/rubrik_cdm/api.py
+++ b/rubrik_cdm/api.py
@@ -32,7 +32,7 @@ class Api():
     def __init__(self, node_ip):
         super().__init__(node_ip)
 
-    def _common_api(self, call_type, api_version, api_endpoint, config=None, job_status_url=None, timeout=15, authentication=True):
+    def _common_api(self, call_type, api_version, api_endpoint, api_vars=None, config=None, job_status_url=None, timeout=15, authentication=True):
         """Internal method that consolidates the base API functions.
 
         Arguments:
@@ -41,6 +41,7 @@ class Api():
             api_endpoint {str} -- The endpoint of the Rubrik CDM API to call (ex. /cluster/me).
 
         Keyword Arguments:
+            api_vars {dict} -- An optional dict containing variables in a key:value format to send with `GET` API calls (default: {None})
             config {dict} -- The specified data to send with `POST` and `PATCH` API calls. (default: {None})
             job_status_url {str} -- The job status URL provided by a previous API call. (default: {None})
             timeout {int} -- The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. (default: {15})
@@ -66,6 +67,8 @@ class Api():
             if call_type == 'GET':
                 request_url = "https://{}/api/{}{}".format(
                     self.node_ip, api_version, api_endpoint)
+                if api_vars is not None:
+                    request_url = request_url + "?" + '&'.join("{}={}".format(key,val) for (key,val) in api_vars.items())
                 request_url = quote(request_url, '://?=&')
                 self.log('GET {}'.format(request_url))
                 api_request = requests.get(
@@ -142,7 +145,7 @@ class Api():
             except BaseException:
                 return {'status_code': api_request.status_code}
 
-    def get(self, api_version, api_endpoint, timeout=15, authentication=True):
+    def get(self, api_version, api_endpoint, api_vars=None, timeout=15, authentication=True):
         """Send a GET request to the provided Rubrik API endpoint.
 
         Arguments:
@@ -150,6 +153,7 @@ class Api():
             api_endpoint {str} -- The endpoint of the Rubrik CDM API to call (ex. /cluster/me).
 
         Keyword Arguments:
+            api_vars {dict} -- An optional dict containing variables in a key:value format to send with `GET` API calls (default: {None})
             timeout {int} -- The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. (default: {15})
             authentication {bool} -- Flag that specifies whether or not to utilize authentication when making the API call. (default: {True})
 
@@ -161,6 +165,7 @@ class Api():
             'GET',
             api_version,
             api_endpoint,
+            api_vars=None,
             config=None,
             job_status_url=None,
             timeout=timeout,

--- a/rubrik_cdm/cloud.py
+++ b/rubrik_cdm/cloud.py
@@ -115,7 +115,7 @@ class Cloud(_API):
         self.log(
             "aws_s3_cloudout: Searching the Rubrik cluster for archival locations.")
         archives_on_cluster = self.get(
-            'internal', '/archive/object_store', timeout)
+            'internal', '/archive/object_store', timeout=timeout)
 
         config = {}
         config['name'] = archive_name
@@ -177,7 +177,7 @@ class Cloud(_API):
         self.log(
             "aws_s3_cloudon: Searching the Rubrik cluster for archival locations.")
         archives_on_cluster = self.get(
-            'internal', '/archive/object_store', timeout)
+            'internal', '/archive/object_store', timeout=timeout)
 
         config = {}
         config['defaultComputeNetworkConfig'] = {}
@@ -239,7 +239,7 @@ class Cloud(_API):
         self.log(
             "azure_cloudout: Searching the Rubrik cluster for archival locations.")
         archives_on_cluster = self.get(
-            'internal', '/archive/object_store', timeout)
+            'internal', '/archive/object_store', timeout=timeout)
 
         config = {}
         config['name'] = archive_name
@@ -348,7 +348,7 @@ class Cloud(_API):
         self.log(
             "azure_cloudon: Searching the Rubrik cluster for archival locations.")
         archives_on_cluster = self.get(
-            'internal', '/archive/object_store', timeout)
+            'internal', '/archive/object_store', timeout=timeout)
 
         config = {}
         config['name'] = archive_name
@@ -502,7 +502,7 @@ class Cloud(_API):
 
         self.log(
             "aws_native_account: Searching the Rubrik cluster for cloud native sources.")
-        cloud_native_on_cluster = self.get('internal', '/aws/account', timeout)
+        cloud_native_on_cluster = self.get('internal', '/aws/account', timeout=timeout)
 
         for cloud_source in cloud_native_on_cluster['data']:
 
@@ -518,7 +518,7 @@ class Cloud(_API):
             # idempotent return if a cloud native source with this access key
             # already exists
             cloud_source_detail = self.get(
-                'internal', '/aws/account/{}'.format(cloud_source['id']), timeout)
+                'internal', '/aws/account/{}'.format(cloud_source['id']), timeout=timeout)
             if cloud_source_detail['accessKey'] == aws_access_key:
                 return "No change required. Cloud native source with access key '{}' is already configured on the Rubrik cluster.".format(
                     aws_access_key)

--- a/rubrik_cdm/cluster.py
+++ b/rubrik_cdm/cluster.py
@@ -37,7 +37,7 @@ class Cluster(_API):
 
         self.log(
             'cluster_version: Getting the software version of the Rubrik cluster.')
-        return self.get('v1', '/cluster/me/version', timeout)['version']
+        return self.get('v1', '/cluster/me/version', timeout=timeout)['version']
 
     def cluster_node_ip(self, timeout=15):
         """Retrive the IP Address for each node in the Rubrik cluster.
@@ -50,7 +50,7 @@ class Cluster(_API):
         """
 
         self.log('cluster_node_ip: Generating a list of all Cluster Node IPs.')
-        api_request = self.get('internal', '/cluster/me/node', timeout)
+        api_request = self.get('internal', '/cluster/me/node', timeout=timeout)
 
         node_ip_list = []
 
@@ -70,7 +70,7 @@ class Cluster(_API):
         """
 
         self.log('cluster_node_ip: Generating a list of all Cluster')
-        api_request = self.get('internal', '/cluster/me/node', timeout)
+        api_request = self.get('internal', '/cluster/me/node', timeout=timeout)
 
         node_ip_name = []
 
@@ -108,7 +108,7 @@ class Cluster(_API):
         self.log(
             "end_user_authorization: Searching the Rubrik cluster for the End User '{}'.".format(end_user))
         user = self.get(
-            'internal', '/user?username={}'.format(end_user), timeout)
+            'internal', '/user?username={}'.format(end_user), timeout=timeout)
 
         if not user:
             sys.exit(
@@ -119,7 +119,7 @@ class Cluster(_API):
         self.log(
             "end_user_authorization: Searching the Rubrik cluster for the End User '{}' authorizations.".format(end_user))
         user_authorization = self.get(
-            'internal', '/authorization/role/end_user?principals={}'.format(user_id), timeout)
+            'internal', '/authorization/role/end_user?principals={}'.format(user_id), timeout=timeout)
 
         authorized_objects = user_authorization['data'][0]['privileges']['restore']
 
@@ -158,7 +158,7 @@ class Cluster(_API):
         self.log(
             "add_vcenter: Searching the Rubrik cluster for the vCenter '{}'.".format(vcenter_ip))
         current_vcenter = self.get(
-            "v1", "/vmware/vcenter?primary_cluster_id=local", timeout)
+            "v1", "/vmware/vcenter?primary_cluster_id=local", timeout=timeout)
 
         for vcenter in current_vcenter["data"]:
             if vcenter["hostname"] == vcenter_ip:
@@ -236,7 +236,7 @@ class Cluster(_API):
                 valid_timezones))
 
         self.log("cluster_timezone: Determing the current cluster timezone")
-        cluster_summary = self.get("v1", "/cluster/me", timeout)
+        cluster_summary = self.get("v1", "/cluster/me", timeout=timeout)
 
         if cluster_summary["timezone"]["timezone"] == timezone:
             return "No change required. The Rubrik cluster is already configured with '{}' as it's timezone.".format(
@@ -267,7 +267,7 @@ class Cluster(_API):
             sys.exit("Error: The 'ntp_server' argument must be a list object.")
 
         self.log("cluster_ntp: Determing the current cluster NTP settings")
-        cluster_ntp = self.get("internal", "/cluster/me/ntp_server", timeout)
+        cluster_ntp = self.get("internal", "/cluster/me/ntp_server", timeout=timeout)
 
         if sorted(cluster_ntp["data"]) == sorted(ntp_server):
             return "No change required. The NTP server(s) {} has already been added to the Rubrik cluster.".format(
@@ -300,7 +300,7 @@ class Cluster(_API):
                 valid_protocols))
 
         self.log("cluster_syslog: Getting the current cluster syslog settings")
-        syslog = self.get("internal", "/syslog", timeout)
+        syslog = self.get("internal", "/syslog", timeout=timeout)
 
         config = {}
         config["hostname"] = syslog_ip
@@ -362,7 +362,7 @@ class Cluster(_API):
                 "Error: The interfaces argument must be either a list of IPs or a dictionary with node_name:ip as the key, value pairs.")
 
         self.log("cluster_vlan: Getting the current VLAN configurations.")
-        current_vlans = self.get("internal", "/cluster/me/vlan", timeout)
+        current_vlans = self.get("internal", "/cluster/me/vlan", timeout=timeout)
         if current_vlans["total"] != 0:
             current_vlans = current_vlans["data"][0]
 
@@ -400,7 +400,7 @@ class Cluster(_API):
         self.log(
             "cluster_dns_servers: Generating a list of DNS servers configured on the Rubrik cluster.")
         current_dns_servers = self.get(
-            "internal", "/cluster/me/dns_nameserver", timeout)
+            "internal", "/cluster/me/dns_nameserver", timeout=timeout)
 
         if sorted(current_dns_servers["data"]) == sorted(server_ip):
             return "No change required. The Rubrik cluster is already configured with the provided DNS servers."
@@ -431,7 +431,7 @@ class Cluster(_API):
         self.log(
             "cluster_dns_servers: Generating a list of DNS servers configured on the Rubrik cluster.")
         current_dns_search_domains = self.get(
-            "internal", "/cluster/me/dns_search_domain", timeout)
+            "internal", "/cluster/me/dns_search_domain", timeout=timeout)
 
         if sorted(current_dns_search_domains["data"]) == sorted(search_domain):
             return "No change required. The Rubrik cluster is already configured with the provided DNS servers."
@@ -471,7 +471,7 @@ class Cluster(_API):
 
         self.log(
             "cluster_smtp_settings: Determing the current SMTP settings on the Rubrik cluster.")
-        current_smtp_settings = self.get("internal", "/smtp_instance", timeout)
+        current_smtp_settings = self.get("internal", "/smtp_instance", timeout=timeout)
 
         config = {}
         config["smtpHostname"] = hostname

--- a/rubrik_cdm/data_management.py
+++ b/rubrik_cdm/data_management.py
@@ -66,7 +66,7 @@ class Data_Management(_API):
                     "on_demand_snapshot: Searching the Rubrik cluster for the SLA Domain assigned to the vSphere VM '{}'.".format(object_name))
 
                 vm_summary = self.get(
-                    'v1', '/vmware/vm/{}'.format(vm_id), timeout)
+                    'v1', '/vmware/vm/{}'.format(vm_id), timeout=timeout)
                 sla_id = vm_summary['effectiveSlaDomainId']
 
             elif sla_name != 'current':
@@ -104,7 +104,7 @@ class Data_Management(_API):
             self.log(
                 "on_demand_snapshot: Searching the Rubrik cluster for the full Fileset.")
             fileset_summary = self.get(
-                'v1', '/fileset?primary_cluster_id=local&host_id={}&is_relic=false&template_id={}'.format(host_id, fileset_template_id), timeout)
+                'v1', '/fileset?primary_cluster_id=local&host_id={}&is_relic=false&template_id={}'.format(host_id, fileset_template_id), timeout=timeout)
 
             if fileset_summary['total'] == 0:
                 sys.exit(
@@ -199,7 +199,7 @@ class Data_Management(_API):
         self.log("object_id: Getting the object id for the {} object '{}'.".format(
             object_type, object_name))
         api_request = self.get(object_summary_api_version,
-                               object_summary_api_endpoint, timeout)
+                               object_summary_api_endpoint, timeout=timeout)
 
         if api_request['total'] == 0:
             sys.exit("Error: The {} object '{}' was not found on the Rubrik cluster.".format(
@@ -274,7 +274,7 @@ class Data_Management(_API):
 
             self.log(
                 "assign_sla: Determing the SLA Domain currently assigned to the vSphere VM '{}'.".format(object_name))
-            vm_summary = self.get('v1', '/vmware/vm/{}'.format(vm_id), timeout)
+            vm_summary = self.get('v1', '/vmware/vm/{}'.format(vm_id), timeout=timeout)
             if sla_id == "INHERIT":
                 current_sla_id = vm_summary['configuredSlaDomainId']
             else:
@@ -330,7 +330,7 @@ class Data_Management(_API):
 
         self.log(
             "vsphere_live_mount: Getting a list of all Snapshots for vSphere VM '{}'.".format(vm_name))
-        vm_summary = self.get('v1', '/vmware/vm/{}'.format(vm_id), timeout)
+        vm_summary = self.get('v1', '/vmware/vm/{}'.format(vm_id), timeout=timeout)
 
         if date == 'latest' and time == 'latest':
             number_of_snapshots = len(vm_summary['snapshots'])
@@ -421,7 +421,7 @@ class Data_Management(_API):
 
         self.log(
             "vsphere_instant_recovery: Getting a list of all Snapshots for vSphere VM '{}'.".format(vm_name))
-        vm_summary = self.get('v1', '/vmware/vm/{}'.format(vm_id), timeout)
+        vm_summary = self.get('v1', '/vmware/vm/{}'.format(vm_id), timeout=timeout)
 
         if date == 'latest' and time == 'latest':
             number_of_snapshots = len(vm_summary['snapshots'])
@@ -501,7 +501,7 @@ class Data_Management(_API):
                 "Error: The time argument '{}' must be formatd as 'Hour:Minute AM/PM' (ex: 2:57 AM).".format(time))
 
         self.log("_date_time_conversion: Getting the Rubrik cluster timezone.")
-        cluster_summary = self.get('v1', '/cluster/me', timeout)
+        cluster_summary = self.get('v1', '/cluster/me', timeout=timeout)
         cluster_timezone = cluster_summary['timezone']['timezone']
 
         self.log(
@@ -552,7 +552,7 @@ class Data_Management(_API):
             self.log(
                 "pause_snapshots: Determing the current pause state of the vSphere VM '{}'.".format(object_name))
             api_request = self.get(
-                'v1', '/vmware/vm/{}'.format(vm_id), timeout)
+                'v1', '/vmware/vm/{}'.format(vm_id), timeout=timeout)
 
             if api_request['blackoutWindowStatus']['isSnappableBlackoutActive']:
                 return "No change required. The '{}' '{}' is already paused.".format(
@@ -597,7 +597,7 @@ class Data_Management(_API):
             self.log(
                 "resume_snapshots: Determing the current pause state of the vSphere VM '{}'.".format(object_name))
             api_request = self.get(
-                'v1', '/vmware/vm/{}'.format(vm_id), timeout)
+                'v1', '/vmware/vm/{}'.format(vm_id), timeout=timeout)
 
             if not api_request['blackoutWindowStatus']['isSnappableBlackoutActive']:
                 return "No change required. The '{}' object '{}' is currently not paused.".format(
@@ -634,7 +634,7 @@ class Data_Management(_API):
         self.log(
             "begin_managed_volume_snapshot: Determing the state of the Managed Volume '{}'.".format(name))
         managed_volume_summary = self.get(
-            'internal', '/managed_volume/{}'.format(managed_volume_id), timeout)
+            'internal', '/managed_volume/{}'.format(managed_volume_id), timeout=timeout)
 
         if not managed_volume_summary['isWritable']:
             self.log(
@@ -671,7 +671,7 @@ class Data_Management(_API):
         self.log(
             "end_managed_volume_snapshot: Determing the state of the Managed Volume '{}'.".format(name))
         managed_volume_summary = self.get(
-            "internal", "/managed_volume/{}".format(managed_volume_id), timeout)
+            "internal", "/managed_volume/{}".format(managed_volume_id), timeout=timeout)
 
         if not managed_volume_summary['isWritable']:
             return "No change required. The Managed Volume 'name' is already assigned in a read only state."
@@ -718,7 +718,7 @@ class Data_Management(_API):
             sla_id = self.object_id(sla, "sla", timeout=timeout)
 
             all_vms_in_sla = self.get(
-                "v1", "/vmware/vm?effective_sla_domain_id={}&is_relic=false".format(sla_id), timeout)
+                "v1", "/vmware/vm?effective_sla_domain_id={}&is_relic=false".format(sla_id), timeout=timeout)
 
             vm_name_id = {}
             for vm in all_vms_in_sla["data"]:

--- a/rubrik_cdm/physical.py
+++ b/rubrik_cdm/physical.py
@@ -84,7 +84,7 @@ class Physical(_API):
 
         self.log(
             "Deleting the host '{}' from the Rubrik cluster.".format(hostname))
-        return self.delete('v1', '/host/{}'.format(host_id), timeout)
+        return self.delete('v1', '/host/{}'.format(host_id), timeout=timeout)
 
     def create_physical_fileset(self, name, operating_system, include, exclude, exclude_exception, follow_network_shares=False, backup_hidden_folders=False, timeout=15):
         """Create a Fileset for a Linux or Windows machine.

--- a/rubrik_cdm/physical.py
+++ b/rubrik_cdm/physical.py
@@ -39,7 +39,7 @@ class Physical(_API):
         """
 
         self.log('Searching the Rubrik cluster for the current hosts.')
-        current_hosts = self.get('v1', '/host', timeout)
+        current_hosts = self.get('v1', '/host', timeout=timeout)
 
         for host in current_hosts['data']:
             if host['hostname'] == hostname:
@@ -68,7 +68,7 @@ class Physical(_API):
         """
 
         self.log('Searching the Rubrik cluster for the current hosts.')
-        current_hosts = self.get('v1', '/host', timeout)
+        current_hosts = self.get('v1', '/host', timeout=timeout)
 
         host_present = False
 
@@ -138,7 +138,7 @@ class Physical(_API):
         self.log("create_fileset: Searching the Rubrik cluster for all current {} Filesets.".format(
             operating_system))
         current_filesets = self.get(
-            'v1', '/fileset_template?primary_cluster_id=local&operating_system_type={}&name={}'.format(operating_system, name), timeout)
+            'v1', '/fileset_template?primary_cluster_id=local&operating_system_type={}&name={}'.format(operating_system, name), timeout=timeout)
 
         current_config = {}
         if current_filesets['data']:
@@ -215,7 +215,7 @@ class Physical(_API):
         self.log(
             "create_fileset: Searching the Rubrik cluster for all current NAS Filesets.")
         current_filesets = self.get(
-            'v1', '/fileset_template?primary_cluster_id=local&operating_system_type=NONE&name={}'.format(name), timeout)
+            'v1', '/fileset_template?primary_cluster_id=local&operating_system_type=NONE&name={}'.format(name), timeout=timeout)
 
         current_config = {}
         if current_filesets['data']:
@@ -302,7 +302,7 @@ class Physical(_API):
                 operating_system,
                 hostname))
         current_hosts = self.get(
-            'v1', '/host?operating_system_type={}&primary_cluster_id=local&hostname={}'.format(operating_system, hostname), timeout)
+            'v1', '/host?operating_system_type={}&primary_cluster_id=local&hostname={}'.format(operating_system, hostname), timeout=timeout)
 
         if current_hosts['total'] >= 1:
             for host in current_hosts['data']:
@@ -319,7 +319,7 @@ class Physical(_API):
         self.log("assign_physical_host_fileset: Searching the Rubrik cluster for all current {} Filesets.".format(
             operating_system))
         current_filesets_templates = self.get(
-            'v1', '/fileset_template?primary_cluster_id=local&operating_system_type={}&name={}'.format(operating_system, fileset_name), timeout)
+            'v1', '/fileset_template?primary_cluster_id=local&operating_system_type={}&name={}'.format(operating_system, fileset_name), timeout=timeout)
 
         number_of_matches = 0
         if current_filesets_templates['total'] == 0:
@@ -385,7 +385,7 @@ class Physical(_API):
         self.log("assign_physical_host_fileset: Getting the properties of the {} Fileset.".format(
             fileset_name))
         current_fileset = self.get(
-            'v1', '/fileset?primary_cluster_id=local&host_id={}&is_relic=false&template_id={}'.format(host_id, fileset_template_id), timeout)
+            'v1', '/fileset?primary_cluster_id=local&host_id={}&is_relic=false&template_id={}'.format(host_id, fileset_template_id), timeout=timeout)
 
         if current_fileset['total'] == 0:
             self.log(


### PR DESCRIPTION
Implementation of an optional params argument to pass with the .get and .delete functions. It has to be a named parameter because the third location is reserved for the timeout argument.

Enhancement to issue #26 

### Example GET Request
```
params = {
    "name": "Python SDK"
}

sla_summary_information = rubrik.get('v1', '/sla_domain', params=params)
```

This enhancement is much easier to maintain than writing the URL in one line.