### PR TITLE
Unit Test - minimum_installed_cdm_version

### DIFF
--- a/rubrik_cdm/cluster.py
+++ b/rubrik_cdm/cluster.py
@@ -33,8 +33,8 @@ class Cluster(Api):
             str -- The version of CDM installed on the Rubrik cluster.
         """
 
-        self.log(
-            'cluster_version: Getting the software version of the Rubrik cluster.')
+        self.log('cluster_version: Getting the software version of the Rubrik cluster.')
+
         return self.get('v1', '/cluster/me/version', timeout=timeout)['version']
 
     def minimum_installed_cdm_version(self, cluster_version, timeout=15):

--- a/tests/unit/cluster_test.py
+++ b/tests/unit/cluster_test.py
@@ -2,7 +2,7 @@ import pytest
 
 
 @pytest.mark.unit
-def test_cluster_version_check(rubrik, monkeypatch):
+def test_cluster_version(rubrik, monkeypatch):
 
     # Result of self.get('v1', '/cluster/me/version', timeout=timeout)
     def patch_get_v1_cluster_me_version(api_version, api_endpoint, timeout):

--- a/tests/unit/cluster_test.py
+++ b/tests/unit/cluster_test.py
@@ -12,3 +12,25 @@ def test_cluster_version(rubrik, monkeypatch):
     monkeypatch.setattr(rubrik, "get", patch_get_v1_cluster_me_version)
 
     assert rubrik.cluster_version() == "5.0.1-1280"
+
+
+@pytest.mark.unit
+def test_minimum_installed_cdm_version_met(rubrik, monkeypatch):
+
+    def patch_cluster_version(timeout):
+        return "5.0.1-1280"
+
+    # Test to validate the version of CDM meets the minimum requirements
+    monkeypatch.setattr(rubrik, "cluster_version", patch_cluster_version)
+    assert rubrik.minimum_installed_cdm_version("5.0") is True
+
+
+@pytest.mark.unit
+def test_minimum_installed_cdm_version_not_met(rubrik, monkeypatch):
+
+    def patch_cluster_version(timeout):
+        return "5.0.1-1280"
+
+    # Test to validate the version of CDM does not meet the minimum requirements
+    monkeypatch.setattr(rubrik, "cluster_version", patch_cluster_version)
+    assert rubrik.minimum_installed_cdm_version("5.2") is False

--- a/tests/unit/cluster_test.py
+++ b/tests/unit/cluster_test.py
@@ -1,15 +1,14 @@
 import pytest
-from rubrik_cdm.exceptions import CDMVersionException
 
 
 @pytest.mark.unit
 def test_cluster_version_check(rubrik, monkeypatch):
 
-    def patch_cluster_version(timeout):
-        return "4.2.1-1417"
+    # Result of self.get('v1', '/cluster/me/version', timeout=timeout)
+    def patch_get_v1_cluster_me_version(api_version, api_endpoint, timeout):
+        return {'version': '5.0.1-1280'}
 
     # Monkey match rubrik.cluster_version to equal the patch_cluster_version() result
-    monkeypatch.setattr(rubrik, "cluster_version", patch_cluster_version)
+    monkeypatch.setattr(rubrik, "get", patch_get_v1_cluster_me_version)
 
-    with pytest.raises(CDMVersionException):
-        rubrik.cluster_version_check("5.0")
+    assert rubrik.cluster_version() == "5.0.1-1280"


### PR DESCRIPTION
# Description

Add unit tests for `minimum_installed_cdm_version()`

This will check to validate the function returns the proper value (true/false) for when the minimum installed version of CDM is present and when it is not.