### PR TITLE
Add MSSQL Snapshot Support, Physical Host Object ID and MSSQL Instance ID

### DIFF
--- a/docs/on_demand_snapshot.md
+++ b/docs/on_demand_snapshot.md
@@ -2,7 +2,7 @@
 
 Initiate an on-demand snapshot.
 ```py
-def on_demand_snapshot(object_name, object_type, sla_name='current', fileset=None, host_os=None, timeout=15)
+def on_demand_snapshot(object_name, object_type, sla_name='current', fileset=None, host_os=None, sql_host=None, sql_instance=None, sql_db=None, timeout=15)
 ```
 
 ## Arguments
@@ -16,6 +16,9 @@ def on_demand_snapshot(object_name, object_type, sla_name='current', fileset=Non
 | sla_name  | str  | The SLA Domain name you want to assign the on-demand snapshot to. By default, the currently assigned SLA Domain will be used.  |         |    current     |
 | fileset  | str  | The name of the Fileset you wish to backup. Only required when taking a on-demand snapshot of a physical host.  |         |    None     |
 | host_os  | str  | The operating system for the physical host. Only required when taking a on-demand snapshot of a physical host.  |    Linux, Windows     |    None      |
+| sql_host  | str  | The name of the SQL Host hosting the specified database. Only required when taking a on-demand snapshot of a MSSQL DB.  |    None     |    None      |
+| sql_instance  | str  | The name of the SQL Instance hosting the specified database. Only required when taking a on-demand snapshot of a MSSQL DB.  |    None     |    None      |
+| sql_db  | str  | TThe name of the SQL DB. Only required when taking a on-demand snapshot of a MSSQL DB.  |    None     |    None      |
 | timeout  | int  | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error.  |         |    15     |
 
 ## Returns
@@ -39,7 +42,7 @@ ahv_vm_name = "python-sdk-demo"
 object_type = "ahv"
 snapshot = rubrik.on_demand_snapshot(ahv_vm_name, object_type)
 
-# Physical Host Snapst
+# Physical Host Snapshot
 physical_host_name = "python-sdk-physical-demo"
 object_type = "physical_host"
 sla = "Gold"
@@ -47,4 +50,10 @@ fileset = "/etc"
 host_os = "Linux"
 
 snapshot = rubrik.on_demand_snapshot(physical_host_name, object_type, sla, fileset, host_os)
+
+# MSSQL DB Snapshot
+object_name = "AdventureWorks2014"
+object_type = "mssql_db"
+
+snapshot = rubrik.on_demand_snapshot(object_name, object_type, sql_host="hostname.rubrik.com", sql_instance="MSSQLSERVER", sql_db="AdventureWorks2014")
 ```

--- a/rubrik_cdm/cluster.py
+++ b/rubrik_cdm/cluster.py
@@ -39,6 +39,20 @@ class Cluster(_API):
             'cluster_version: Getting the software version of the Rubrik cluster.')
         return self.get('v1', '/cluster/me/version', timeout=timeout)['version']
 
+    def minimum_installed_cdm_version(self, cluster_version, timeout=15):
+            """Determine if the Rubrik cluster is running the provided CDM `cluster_version` or later. If the cluster is running an earlier release
+            of CDM, `False` is returned. If the cluster is running the provided `cluster_version`, or a later release, `True` is returned.
+            Arguments:
+                cluster_version {float} -- The minimum required version of Rubrik CDM you wish ensure is running.
+            Keyword Arguments:
+                timeout {int} -- The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. (default: {15})
+            """
+
+            if float(self.cluster_version(timeout)[:3]) < float(cluster_version):
+                return False
+
+            return True
+
     def cluster_node_ip(self, timeout=15):
         """Retrive the IP Address for each node in the Rubrik cluster.
 


### PR DESCRIPTION
Add MSSQL Snapshot Support, Physical Host Object ID and MSSQL Instance ID

# Description

* Adding support for On-Demand Snapshot for MSSQL
* Adding New Object ID types - MSSQL DB, MSSQL Instance, Physical Host

## Related Issue

https://github.com/rubrikinc/rubrik-sdk-for-python/issues/42

## Motivation and Context

Provides capability to take On-Demand Snapshots for MSSQL

## How Has This Been Tested?
Script ran (Hostname redacted)

```
import rubrik_cdm
rubrik = rubrik_cdm.Connect(node_ip, username, password, enable_logging=True)
object_name = "AdventureWorks2014"
object_type = "mssql_db"
snapshot = rubrik.on_demand_snapshot(object_name, object_type, sql_host="hostname.rubrik.com", sql_instance="MSSQLSERVER", sql_db="AdventureWorks2014")

[2019-04-12 16:23:23,372] [DEBUG] -- on_demand_snapshot: Searching the Rubrik cluster for the MS SQL 'AdventureWorks2014'.
[2019-04-12 16:23:23,372] [DEBUG] -- cluster_version: Getting the software version of the Rubrik cluster.
[2019-04-12 16:23:24,845] [DEBUG] -- <Response [200]>
[2019-04-12 16:23:24,846] [DEBUG] -- object_id: Getting the object id for the physical_host object 'hostname.rubrik.com'.
[2019-04-12 16:23:26,502] [DEBUG] -- <Response [200]>
[2019-04-12 16:23:26,503] [DEBUG] -- cluster_version: Getting the software version of the Rubrik cluster.
[2019-04-12 16:23:27,931] [DEBUG] -- <Response [200]>
[2019-04-12 16:23:30,060] [DEBUG] -- GET https://hostname.rubrik.com/api/v1/mssql/db?primary_cluster_id=local&instance_id=MssqlInstance:::a2a1fb81-e3f7-4b13-99ef-a09ea8cc30b5
[2019-04-12 16:23:30,060] [DEBUG] -- <Response [200]>
[2019-04-12 16:23:30,060] [DEBUG] -- GET https://hostname.rubrik.com/api/v1/mssql/db?primary_cluster_id=local&instance_id=MssqlInstance:::a2a1fb81-e3f7-4b13-99ef-a09ea8cc30b5
[2019-04-12 16:23:32,339] [DEBUG] -- <Response [200]>
[2019-04-12 16:23:32,340] [DEBUG] -- on_demand_snapshot: Searching the Rubrik cluster for the SLA Domain assigned to the MS SQL 'AdventureWorks2014'.
[2019-04-12 16:23:36,724] [DEBUG] -- <Response [200]>
[2019-04-12 16:23:36,724] [DEBUG] -- on_demand_snapshot: Initiating snapshot for the MS SQL 'AdventureWorks2014'.
[2019-04-12 16:23:36,725] [DEBUG] -- POST https://hostname.rubrik.com/api/v1/mssql/db/MssqlDatabase:::5b23bf34-817e-4816-bef0-2568c0fb7e05/snapshot
[2019-04-12 16:23:36,725] [DEBUG] -- Config: {"slaId": "bc50f94c-4d7f-41c8-8603-d2e80c589371"}
[2019-04-12 16:23:41,528] [DEBUG] -- <Response [202]>
Request ID: https://hostname.rubrik.com/api/v1/mssql/request/MSSQL_DB_BACKUP_80c188e2-a0b1-49ac-b9f3-c1eebf984c4e_9cc36d1e-02e6-4f4a-9dfb-6d09dd3ba04f:::0
```
## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/rubrik-sdk-for-python/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
