### PR TITLE
Add MSSQL Host Assign SLA Function

### DIFF
--- a/docs/assign_sla.md
+++ b/docs/assign_sla.md
@@ -10,7 +10,10 @@ def assign_sla(object_name, sla_name, object_type, timeout=30)
 |-------------|------|-----------------------------------------------------------------------------|---------|
 | object_name  | str  | The name of the Rubrik object you wish to assign to an SLA Domain. |         |
 | sla_name  | str  | The name of the SLA Domain you wish to assign an object to. To exclude the object from all SLA assignments use `do not protect` as the `sla_name`. To assign the selected object to the SLA of the next higher level object use `clear` as the `sla_name`. |         |
-| object_type  | str  | The Rubrik object type you want to assign to the SLA Domain.  |    vmware     |
+| object_type  | str  | The Rubrik object type you want to assign to the SLA Domain.  |    vmware, mssql_host     |
+| log_backup_frequency_in_seconds  | int  | (Optional) The MSSQL Log Backup frequency you'd like to specify with the SLA  |         |
+| log_retention_hours  | int  | (Optional) The MSSQL Log Retention frequency you'd like to specify with the SLA |         |
+| copy_only  | bool  | (Optional) Take Copy Only Backups with MSSQL  |         |
 ## Keyword Arguments
 | Name        | Type | Description                                                                 | Choices | Default |
 |-------------|------|-----------------------------------------------------------------------------|---------|---------|
@@ -21,7 +24,9 @@ def assign_sla(object_name, sla_name, object_type, timeout=30)
 |------|-----------------------------------------------------------------------------------------------|
 | str  | No change required. The vSphere VM '`object_name`' is already assigned to the '`sla_name`' SLA Domain. |
 | dict  | The full API reponse for `POST /internal/sla_domain/{sla_id}/assign`. |
+
 ## Example
+### VMware
 ```py
 import rubrik_cdm
 
@@ -32,4 +37,20 @@ sla_name = "Gold"
 object_type = "vmware"
 
 assign_sla = rubrik.assign_sla(vm_name, sla_name, object_type)
+```
+### MSSQL
+```py
+import rubrik_cdm
+
+rubrik = rubrik_cdm.Connect()
+
+object_name = 'python-sdk.demo.com'
+object_type = 'mssql_host'
+
+sla_name = 'Gold'
+log_backup_frequency_in_seconds = 600
+log_retention_hours = 12
+copy_only = False
+
+assignsla = rubrik.assign_sla(object_name, sla_name, object_type, logBackupFrequencyInSeconds, logRetentionHours, copyOnly)
 ```

--- a/rubrik_cdm/data_management.py
+++ b/rubrik_cdm/data_management.py
@@ -225,7 +225,7 @@ class Data_Management(_API):
             'fileset_template',
             'managed_volume',
             'mssql_db',
-            'mssql_instance'
+            'mssql_instance',
             'vcenter',
             'ahv',
             'aws_native']
@@ -325,7 +325,7 @@ class Data_Management(_API):
                 "The {} object '{}' was not found on the Rubrik cluster.".format(
                     object_type, object_name))
 
-    def assign_sla(self, object_name, sla_name, object_type, timeout=30):
+    def assign_sla(self, object_name, sla_name, object_type, log_backup_frequency_in_seconds, log_retention_hours, copy_only, timeout=30):
         """Assign a Rubrik object to an SLA Domain.
 
         Arguments:
@@ -341,7 +341,7 @@ class Data_Management(_API):
             dict -- The full API reponse for `POST /internal/sla_domain/{sla_id}/assign`.
         """
 
-        valid_object_type = ['vmware']
+        valid_object_type = ['vmware', 'mssql_host']
 
         if object_type not in valid_object_type:
             raise InvalidParameterException(
@@ -376,6 +376,58 @@ class Data_Management(_API):
                 config['managedIds'] = [vm_id]
 
                 return self.post("internal", "/sla_domain/{}/assign".format(sla_id), config, timeout)
+
+        elif object_type == 'mssql_host':
+
+            host_id = ''
+            mssql_id = ''
+            db_sla_lst = []
+
+            self.log('Searching the Rubrik cluster for the current hosts.')
+            current_hosts = self.get('v1', '/host?operating_system_type=Windows&primary_cluster_id=local', timeout=timeout)
+
+            for rubrik_host in current_hosts['data']:
+                if rubrik_host['name'] == object_name:
+                    host_id = rubrik_host['id']
+
+            if(host_id):
+                self.log("assign_sla: Searching the Rubrik cluster for the MSSQL Instance '{}'.".format(object_name))
+                mssql_instances = self.get('v1','/mssql/instance?root_id={}'.format(host_id), timeout=timeout)
+
+                for mssql_instance in mssql_instances['data']:
+                    mssql_id = mssql_instance['id']
+                    mssql_instance_name = mssql_instance['name']
+
+                    self.log("assign_sla: Determing the SLA Domain currently assigned to the MSSQL Instance '{}'.".format(mssql_instance_name))
+
+                    mssql_summary = self.get('v1', '/mssql/instance/{}'.format(mssql_id), timeout=timeout)
+
+                    if (sla_id == mssql_summary['configuredSlaDomainId'] and log_backup_frequency_in_seconds == mssql_summary['logBackupFrequencyInSeconds'] and
+                    log_retention_hours == mssql_summary['logRetentionHours'] and copy_only == mssql_summary['copyOnly']):
+                        return "No change required. The MSSQL Instance '{}' is already assigned to the '{}' SLA Domain with the following log settings:" \
+                               " logBackupFrequencyInSeconds: {}, logRetentionHours: {} and Copy Only: {}.".format(
+                            object_name, sla_name, log_backup_frequency_in_seconds, log_retention_hours, copy_only)
+
+                    else:
+                        self.log("assign_sla: Assigning the MSSQL Instance '{}' to the '{}' SLA Domain.".format(object_name, sla_name))
+
+                        config = {}
+                        if log_backup_frequency_in_seconds is not None:
+                            config['logBackupFrequencyInSeconds'] = log_backup_frequency_in_seconds
+                        if log_retention_hours is not None:
+                            config['logRetentionHours'] = log_retention_hours
+                        if copy_only is not None:
+                            config['copyOnly'] = copy_only
+
+                        config['configuredSlaDomainId'] = sla_id
+
+                        patch_resp = self.patch("v1", "/mssql/instance/{}".format(mssql_id), config, timeout)
+                        db_sla_lst.append(patch_resp)
+            else:
+                raise InvalidParameterException(
+                    "Host ID not found for instance '{}'").format(object_name)
+
+            return db_sla_lst
 
     def vsphere_live_mount(self, vm_name, date='latest', time='latest', host='current',
                            remove_network_devices=False, power_on=True, timeout=15):


### PR DESCRIPTION
# Description

Adding functionality to allow assigning SLA to a MSSQL Host and all subsequent instances under the host.

## Related Issue

Related Issue: https://github.com/rubrikinc/rubrik-sdk-for-python/issues/70

## Motivation and Context

Allows customers to apply SLA to an overall host

## How Has This Been Tested?

```
[2019-05-13 23:44:42,836] [DEBUG] -- Node IP: <ip_redacted>
[2019-05-13 23:44:42,836] [DEBUG] -- Username: <user_redacted>
[2019-05-13 23:44:42,836] [DEBUG] -- Password: *******

>>> 
>>> object_type = 'mssql_host'
>>> object_name = '<host_redacted>'
>>> sla_name = 'Gold'
>>> logBackupFrequencyInSeconds = 600
>>> logRetentionHours = 12
>>> copyOnly = False
>>> 
>>> assignsla = rubrik.assign_sla(object_name, sla_name, object_type, logBackupFrequencyInSeconds, logRetentionHours, copyOnly)
[2019-05-13 23:44:43,234] [DEBUG] -- assign_sla: Searching the Rubrik cluster for the SLA Domain 'Gold'.
[2019-05-13 23:44:43,234] [DEBUG] -- object_id: Getting the object id for the sla object 'Gold'.
[2019-05-13 23:44:43,234] [DEBUG] -- Creating the authorization header using the provided username and password.
[2019-05-13 23:44:43,235] [DEBUG] -- GET https://<ip_redacted>/api/v1/sla_domain?primary_cluster_id=local&name=Gold
[2019-05-13 23:44:45,330] [DEBUG] -- <Response [200]>

[2019-05-13 23:44:45,331] [DEBUG] -- Searching the Rubrik cluster for the current hosts.
[2019-05-13 23:44:45,331] [DEBUG] -- Creating the authorization header using the provided username and password.
[2019-05-13 23:44:45,331] [DEBUG] -- GET https://<ip_redacted>/api/v1/host?operating_system_type=Windows&primary_cluster_id=local
[2019-05-13 23:44:47,068] [DEBUG] -- <Response [200]>

[2019-05-13 23:44:47,069] [DEBUG] -- assign_sla: Searching the Rubrik cluster for the MSSQL Instance '<host_redacted>'.
[2019-05-13 23:44:47,069] [DEBUG] -- Creating the authorization header using the provided username and password.
[2019-05-13 23:44:47,069] [DEBUG] -- GET https://<ip_redacted>/api/v1/mssql/instance?root_id=Host:::32c0637b-6398-4f66-816c-044b2073b3cf
[2019-05-13 23:44:49,469] [DEBUG] -- <Response [200]>

[2019-05-13 23:44:49,470] [DEBUG] -- assign_sla: Determing the SLA Domain currently assigned to the MSSQL Instance 'MSSQLSERVER'.
[2019-05-13 23:44:49,470] [DEBUG] -- Creating the authorization header using the provided username and password.
[2019-05-13 23:44:49,470] [DEBUG] -- GET https://<ip_redacted>/api/v1/mssql/instance/MssqlInstance:::1b906a15-8197-4408-9ae3-109068ebf5f3
[2019-05-13 23:44:51,629] [DEBUG] -- <Response [200]>

[2019-05-13 23:44:51,629] [DEBUG] -- assign_sla: Assigning the MSSQL Instance '<host_redacted>' to the 'Gold' SLA Domain.
[2019-05-13 23:44:51,629] [DEBUG] -- Creating the authorization header using the provided username and password.
[2019-05-13 23:44:51,629] [DEBUG] -- PATCH https://<ip_redacted>/api/v1/mssql/instance/MssqlInstance:::1b906a15-8197-4408-9ae3-109068ebf5f3
[2019-05-13 23:44:51,630] [DEBUG] -- Config: {"configuredSlaDomainId": "8e6f6618-6af0-4833-a94d-6b32f00ca9b0", "logRetentionHours": 12, "logBackupFrequencyInSeconds": 600, "copyOnly": false}
[2019-05-13 23:44:57,236] [DEBUG] -- <Response [200]>

>>> print assignsla
[{u'rootProperties': {u'rootType': u'Host', u'rootId': u'Host:::32c0637b-6398-4f66-816c-044b2073b3cf', u'rootName': u'<host_redacted>'}, u'logBackupFrequencyInSeconds': 600, u'name': u'MSSQLSERVER', u'primaryClusterId': u'603109f2-eb30-4da8-9389-911d66abb524', u'configuredSlaDomainName': u'Gold', u'unprotectableReasons': [], u'id': u'MssqlInstance:::1b906a15-8197-4408-9ae3-109068ebf5f3', u'version': u'11.0.6020.0', u'configuredSlaDomainId': u'8e6f6618-6af0-4833-a94d-6b32f00ca9b0', u'internalTimestamp': 1557787493431000, u'protectionDate': u'2019-05-13T22:44:53.431Z', u'logRetentionHours': 12, u'copyOnly': False}]
```

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/rubrik-sdk-for-python/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
