### PR TITLE
Optional params for MSSQL in assign_sla()

### DIFF
--- a/docs/assign_sla.md
+++ b/docs/assign_sla.md
@@ -6,24 +6,24 @@ def assign_sla(object_name, sla_name, object_type, timeout=30)
 ```
 
 ## Arguments
-| Name        | Type | Description                                                                 | Choices |
-|-------------|------|-----------------------------------------------------------------------------|---------|
-| object_name  | str  | The name of the Rubrik object you wish to assign to an SLA Domain. |         |
-| sla_name  | str  | The name of the SLA Domain you wish to assign an object to. To exclude the object from all SLA assignments use `do not protect` as the `sla_name`. To assign the selected object to the SLA of the next higher level object use `clear` as the `sla_name`. |         |
-| object_type  | str  | The Rubrik object type you want to assign to the SLA Domain.  |    vmware, mssql_host     |
-| log_backup_frequency_in_seconds  | int  | (Optional) The MSSQL Log Backup frequency you'd like to specify with the SLA  |         |
-| log_retention_hours  | int  | (Optional) The MSSQL Log Retention frequency you'd like to specify with the SLA |         |
-| copy_only  | bool  | (Optional) Take Copy Only Backups with MSSQL  |         |
+| Name                            | Type | Description                                                                                                                                                                                                                                                | Choices            |
+|---------------------------------|------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|
+| object_name                     | str  | The name of the Rubrik object you wish to assign to an SLA Domain.                                                                                                                                                                                         |                    |
+| sla_name                        | str  | The name of the SLA Domain you wish to assign an object to. To exclude the object from all SLA assignments use `do not protect` as the `sla_name`. To assign the selected object to the SLA of the next higher level object use `clear` as the `sla_name`. |                    |
+| object_type                     | str  | The Rubrik object type you want to assign to the SLA Domain.                                                                                                                                                                                               | vmware, mssql_host |
+| log_backup_frequency_in_seconds | int  | (Optional) The MSSQL Log Backup frequency you'd like to specify with the SLA. Required when the `object_type` is `mssql_host`.                                                                                                                             |                    |
+| log_retention_hours             | int  | (Optional) The MSSQL Log Retention frequency you'd like to specify with the SLA. Required when the `object_type` is `mssql_host`.                                                                                                                          |                    |
+| copy_only                       | bool | (Optional) Take Copy Only Backups with MSSQL. Required when the `object_type` is `mssql_host`.                                                                                                                                                             |                    |
 ## Keyword Arguments
-| Name        | Type | Description                                                                 | Choices | Default |
-|-------------|------|-----------------------------------------------------------------------------|---------|---------|
-| timeout  | str  | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error.  |         |    30     |
+| Name    | Type | Description                                                                                                  | Choices | Default |
+|---------|------|--------------------------------------------------------------------------------------------------------------|---------|---------|
+| timeout | str  | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. |         | 30      |
 
 ## Returns
-| Type | Return Value                                                                                   |
-|------|-----------------------------------------------------------------------------------------------|
+| Type | Return Value                                                                                           |
+|------|--------------------------------------------------------------------------------------------------------|
 | str  | No change required. The vSphere VM '`object_name`' is already assigned to the '`sla_name`' SLA Domain. |
-| dict  | The full API reponse for `POST /internal/sla_domain/{sla_id}/assign`. |
+| dict | The full API reponse for `POST /internal/sla_domain/{sla_id}/assign`.                                  |
 
 ## Example
 ### VMware

--- a/rubrik_cdm/data_management.py
+++ b/rubrik_cdm/data_management.py
@@ -422,10 +422,6 @@ class Data_Management(_API):
 
         elif object_type == 'mssql_host':
 
-            if log_backup_frequency_in_seconds is None or log_retention_hours is None or copy_only is None:
-                raise InvalidParameterException(
-                    "When the object_type is 'mssql_host' the 'log_backup_frequency_in_seconds', 'log_retention_hours', 'copy_only' paramaters must be populated.")
-
             host_id = ''
             mssql_id = ''
             db_sla_lst = []

--- a/rubrik_cdm/data_management.py
+++ b/rubrik_cdm/data_management.py
@@ -367,10 +367,13 @@ class Data_Management(_API):
         Arguments:
             object_name {str} -- The name of the Rubrik object you wish to assign to an SLA Domain.
             sla_name {str} -- The name of the SLA Domain you wish to assign an object to. To exclude the object from all SLA assignments use `do not protect` as the `sla_name`. To assign the selected object to the SLA of the next higher level object use `clear` as the `sla_name`.
-            object_type {str} -- The Rubrik object type you want to assign to the SLA Domain. (choices: {vmware})
+            object_type {str} -- The Rubrik object type you want to assign to the SLA Domain. (choices: {vmware, mssql_host})
 
         Keyword Arguments:
-            timeout {str} -- The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. (default: {30})
+            log_backup_frequency_in_seconds {str} -- The MSSQL Log Backup frequency you'd like to specify with the SLA. Required when the `object_type` is `mssql_host`. (default {None})
+            log_retention_hours {int} -- The MSSQL Log Retention frequency you'd like to specify with the SLA. Required when the `object_type` is `mssql_host`. (default {None})
+            copy_only {int} -- Take Copy Only Backups with MSSQL. Required when the `object_type` is `mssql_host`. (default {None})
+            timeout {bool} -- The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. (default: {30})
 
         Returns:
             str -- No change required. The vSphere VM '`object_name`' is already assigned to the '`sla_name`' SLA Domain.

--- a/tests/unit/data_management_test.py
+++ b/tests/unit/data_management_test.py
@@ -2625,7 +2625,7 @@ def test_assign_sla_invalid_object_type(rubrik):
 
     error_message = error.value.args[0]
 
-    assert error_message == "The assign_sla() object_type argument must be one of the following: ['vmware']."
+    assert error_message == "The assign_sla() object_type argument must be one of the following: ['vmware', 'mssql_host']."
 
 
 def test_assign_sla_idempotence_specific_sla(rubrik, mocker):


### PR DESCRIPTION
# Description

Make the MSSQL params in `assign_sla()` optional

## Motivation and Context

- Prevents the user from having to enter the MSSQL specific params when using other object_types()
- all unit tests now pass

