### PR TITLE
Job status bug

### DIFF
--- a/rubrik_cdm/api.py
+++ b/rubrik_cdm/api.py
@@ -57,8 +57,6 @@ class Api():
         Returns:
             dict -- The full API call response for the provided endpoint.
         """
-        if call_type != 'JOB_STATUS':
-            self._api_validation(api_version, api_endpoint)
 
         # Determine if authentication should be sent as part of the API Header
         if authentication:
@@ -69,7 +67,9 @@ class Api():
             raise InvalidTypeException('"authentication" must be either True or False')
 
         # Create required header for the special case of a bootstrap including Host attribute
-        if api_endpoint is not None:
+        if call_type != 'JOB_STATUS':
+            self._api_validation(api_version, api_endpoint)
+
             if '/cluster/me/bootstrap' in api_endpoint:
                 if self.ipv6_addr != "":
                     header = {

--- a/rubrik_cdm/api.py
+++ b/rubrik_cdm/api.py
@@ -69,20 +69,21 @@ class Api():
             raise InvalidTypeException('"authentication" must be either True or False')
 
         # Create required header for the special case of a bootstrap including Host attribute
-        if '/cluster/me/bootstrap' in api_endpoint:
-            if self.ipv6_addr != "":
-                header = {
-                    'Content-Type': 'application/json',
-                    'Accept': 'application/json',
-                    'Host': '[' + self.ipv6_addr + ']'
-                }
-                self.log('Created boostrap header: ' + str(header))
-            else:
-                header = {
-                    'Content-Type': 'application/json',
-                    'Accept': 'application/json',
-                }
-                self.log('Created boostrap header: ' + str(header))
+        if api_endpoint is not None:
+            if '/cluster/me/bootstrap' in api_endpoint:
+                if self.ipv6_addr != "":
+                    header = {
+                        'Content-Type': 'application/json',
+                        'Accept': 'application/json',
+                        'Host': '[' + self.ipv6_addr + ']'
+                    }
+                    self.log('Created boostrap header: ' + str(header))
+                else:
+                    header = {
+                        'Content-Type': 'application/json',
+                        'Accept': 'application/json',
+                    }
+                    self.log('Created boostrap header: ' + str(header))
 
         try:
             # Determine which call type is being used and then set the relevant


### PR DESCRIPTION
# Description

When running checks related to IPv6 bootstrap support we attempt to validate against the provided `api_endpoint`. However, when calling `job_status` there is no `api_endpoint` provided which results in a `argument of type 'NoneType' is not iterable` error. 

This PR prevents that check from occurring when the `call_type` is `JOB_STATUS`.

## Related Issue

https://github.com/rubrikinc/rubrik-modules-for-ansible/issues/40


## Motivation and Context

Bug fix for when calling job_status()

## How Has This Been Tested?

```
[2019-05-25 06:02:08,174] [DEBUG] -- Node IP: 172.21.8.53
[2019-05-25 06:02:08,174] [DEBUG] -- API Token: *******

[2019-05-25 06:02:08,174] [DEBUG] -- on_demand_snapshot: Searching the Rubrik cluster for the vSphere VM 'ansible-node01'.
[2019-05-25 06:02:08,174] [DEBUG] -- object_id: Getting the object id for the vmware object 'ansible-node01'.
[2019-05-25 06:02:08,174] [DEBUG] -- Creating the authorization header using the provided API Token.
[2019-05-25 06:02:08,174] [DEBUG] -- GET https://172.21.8.53/api/v1/vmware/vm?primary_cluster_id=local&is_relic=false&name=ansible-node01
[2019-05-25 06:02:10,069] [DEBUG] -- <Response [200]>

[2019-05-25 06:02:10,069] [DEBUG] -- on_demand_snapshot: Searching the Rubrik cluster for the SLA Domain assigned to the vSphere VM 'ansible-node01'.
[2019-05-25 06:02:10,069] [DEBUG] -- Creating the authorization header using the provided API Token.
[2019-05-25 06:02:10,069] [DEBUG] -- GET https://172.21.8.53/api/v1/vmware/vm/VirtualMachine:::e6a7e6f1-6049-4d44-9ba6-8e284e2801de-vm-204969
[2019-05-25 06:02:11,153] [DEBUG] -- <Response [200]>

[2019-05-25 06:02:11,154] [DEBUG] -- on_demand_snapshot: Initiating snapshot for the vSphere VM 'ansible-node01'.
[2019-05-25 06:02:11,154] [DEBUG] -- Creating the authorization header using the provided API Token.
[2019-05-25 06:02:11,155] [DEBUG] -- POST https://172.21.8.53/api/v1/vmware/vm/VirtualMachine:::e6a7e6f1-6049-4d44-9ba6-8e284e2801de-vm-204969/snapshot
[2019-05-25 06:02:11,155] [DEBUG] -- Config: {"slaId": "8e6f6618-6af0-4833-a94d-6b32f00ca9b0"}
[2019-05-25 06:02:11,972] [DEBUG] -- Response: {"id":"CREATE_VMWARE_SNAPSHOT_e6a7e6f1-6049-4d44-9ba6-8e284e2801de-vm-204969_aea56893-9c58-46fb-be50-ba04d15edfcb:::0","status":"QUEUED","progress":0.0,"startTime":"2019-05-25T11:02:11.785Z","links":[{"href":"https://172.21.8.53/api/v1/vmware/vm/request/CREATE_VMWARE_SNAPSHOT_e6a7e6f1-6049-4d44-9ba6-8e284e2801de-vm-204969_aea56893-9c58-46fb-be50-ba04d15edfcb:::0","rel":"self"}]}
[2019-05-25 06:02:11,972] [DEBUG] -- <Response [202]>

[2019-05-25 06:02:11,972] [DEBUG] -- Job Status: Waiting for the job to complete.
[2019-05-25 06:02:11,972] [DEBUG] -- Creating the authorization header using the provided API Token.
[2019-05-25 06:02:11,972] [DEBUG] -- JOB STATUS for https://172.21.8.53/api/v1/vmware/vm/request/CREATE_VMWARE_SNAPSHOT_e6a7e6f1-6049-4d44-9ba6-8e284e2801de-vm-204969_aea56893-9c58-46fb-be50-ba04d15edfcb:::0
[2019-05-25 06:02:12,394] [DEBUG] -- <Response [200]>

[2019-05-25 06:02:12,394] [DEBUG] -- Creating the authorization header using the provided API Token.
[2019-05-25 06:02:12,394] [DEBUG] -- JOB STATUS for https://172.21.8.53/api/v1/vmware/vm/request/CREATE_VMWARE_SNAPSHOT_e6a7e6f1-6049-4d44-9ba6-8e284e2801de-vm-204969_aea56893-9c58-46fb-be50-ba04d15edfcb:::0
[2019-05-25 06:02:12,829] [DEBUG] -- <Response [200]>

[2019-05-25 06:02:12,830] [DEBUG] -- Job Progress 0.0%
```


## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

