### PR TITLE
Added config argument to the delete function to support role endpoints.

### DIFF
--- a/docs/delete.md
+++ b/docs/delete.md
@@ -11,11 +11,12 @@ def delete(api_version, api_endpoint, timeout=15, authentication=True)
 | api_version  | str  | The version of the Rubrik CDM API to call.                    | v1, v2, internal |
 | api_endpoint | str  | The endpoint of the Rubrik CDM API to call (ex. /cluster/me). |                  |
 ## Keyword Arguments
-| Name           | Type | Description                                                                                                  | Choices | Default |
-|----------------|------|--------------------------------------------------------------------------------------------------------------|---------|---------|
-| params         | dict | An optional dict containing variables in a key:value format to send with `GET` & `DELETE` API calls          |         | None    |
-| timeout        | int  | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. |         | 15      |
-| authentication | bool | Flag that specifies whether or not to utilize authentication when making the API call.                       |         | True    |
+| Name           | Type | Description                                                                                                                  | Choices | Default |
+|----------------|------|------------------------------------------------------------------------------------------------------------------------------|---------|---------|
+| params         | dict | An optional dict containing variables in a key:value format to send with `DELETE` API calls. Mutually exclusive with config. |         | None    |
+| config         | dict | The specified data to send with `DELETE` API calls. Mutually exclusive with params.                                          |         | None    |
+| timeout        | int  | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error.                 |         | 15      |
+| authentication | bool | Flag that specifies whether or not to utilize authentication when making the API call.                                       |         | True    |
 
 ## Returns
 | Type | Return Value                       |


### PR DESCRIPTION
# Description

The delete function in api.py required a config file be used instead of parameters to do deleted from /authorization/role endpoints

## Related Issue

This project only accepts pull requests related to open issues.

* If suggesting a new feature or change, please discuss it in an issue first.
* If fixing a bug, there should be an issue describing it with steps to reproduce

https://github.com/rubrikinc/rubrik-sdk-for-python/issues/97

## Motivation and Context

Required to use DELETE to remove objects from roles.

## How Has This Been Tested?

Ran some delete commands that used the config. Test the error catching when both the params and config are set.

## Screenshots (if appropriate):

## Types of changes
Added passing a config to the delete function. Added checks that a param and config are not used at the same time.
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/rubrik-sdk-for-python/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
