### PR TITLE
assign_sla() backwards compatibility bug

### DIFF
--- a/rubrik_cdm/data_management.py
+++ b/rubrik_cdm/data_management.py
@@ -389,8 +389,14 @@ class Data_Management(_API):
                 '/host?operating_system_type=Windows&primary_cluster_id=local',
                 timeout=timeout)
 
+            # After 5.0, "hostname" is a deprecated field in the results that are returned in "current_hosts"
+            if self.minimum_installed_cdm_version(5.0):
+                current_hosts_name = "name"
+            else:
+                current_hosts_name = "hostname"
+
             for rubrik_host in current_hosts['data']:
-                if rubrik_host['name'] == object_name:
+                if rubrik_host[current_hosts_name] == object_name:
                     host_id = rubrik_host['id']
 
             if(host_id):


### PR DESCRIPTION
# Description

In 5.0 we introduced a new `name` field in the `current_hosts()` results which deprecated the `hostname` that was used in previous CDM versions. This PR adds a check for that to prevent an error for being thrown on older CDM versions where `name` may not be present.

## How Has This Been Tested?
* manual integration test


## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

