### PR TITLE
add support for password authentication against Domain Display Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Rubrik SDK for Python
 
+[![CircleCI](https://circleci.com/gh/rubrikinc/rubrik-sdk-for-python/tree/master.svg?style=svg)](https://circleci.com/gh/rubrikinc/rubrik-sdk-for-python/tree/master)
+
 This project provides a Python package that makes it easy to interact with the Rubrik CDM API.
 
 The SDK has been tested against Python 2.7.6 and Python 3.6.4.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ By default, the Rubrik SDK will attempt to read the the Rubrik Cluster credentia
 * `rubrik_cdm_node_ip`
 * `rubrik_cdm_username`
 * `rubrik_cdm_password`
+* `rubrik_cdm_domain`
 
 ```py
 import rubrik_cdm

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -15,6 +15,7 @@ Storing credentials in environment variables is a more secure process than direc
 * **`rubrik_cdm_node_ip`** (Contains the IP/FQDN of a Rubrik node)
 * **`rubrik_cdm_username`** (Contains a username with configured access to the Rubrik cluster)
 * **`rubrik_cdm_password`** (Contains the password for the above user)
+* **`rubrik_cdm_domain`** (Contains the Domain Display Name. If unspecified, the username and password are tried against all the configured authentication domains.)
 
 The way in which to populate these environment variables differs depending on the operating system running Python. Below are examples for Windows, Linux, and Mac OS.
 


### PR DESCRIPTION
# Description

In 5.0, the optional Domain Display Name allows one to specify the authentication domain. If unspecified, Rubrik CDM will first the "local" domain before searching through all the configured LDAP domains. This could be slow and create many false authentication failures. Hence, add an option to Connect() to specify the Domain Display Name.

This change then switches from password authentication to a token based authentication; potentially speeding up further interactions.

## Related Issue

https://github.com/rubrikinc/rubrik-sdk-for-python/issues/104

## Motivation and Context

For customers who have many LDAP integrations, the current behavior will lead to many
false alarms.

## How Has This Been Tested?

Tested against an internal Brik.

_$ python_
Python 3.7.3 (default, Mar 27 2019, 09:23:15)
[Clang 10.0.1 (clang-1001.0.46.3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> _import rubrik_cdm_
>>> _rubrik=rubrik_cdm.Connect(username='surendar@rubrik-lab.com', domain_display_name='Rubrik Lab')_
/Users/surendar/rubrik-sdk-for-python/venv/lib/python3.7/site-packages/urllib3-1.25.3-py3.7.egg/urllib3/connectionpool.py:851: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
>>> _rubrik.cluster_version()_
/Users/surendar/rubrik-sdk-for-python/venv/lib/python3.7/site-packages/urllib3-1.25.3-py3.7.egg/urllib3/connectionpool.py:851: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
'5.0.2-1614'

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/rubrik-sdk-for-python/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.