### PR TITLE
Add support for volume groups in "assign__sla()"

### DIFF
--- a/docs/assign_sla.md
+++ b/docs/assign_sla.md
@@ -2,24 +2,27 @@
 
 Assign a Rubrik object to an SLA Domain.
 ```py
-def assign_sla(object_name, sla_name, object_type, timeout=30)
+def assign_sla(self, object_name, sla_name, object_type, log_backup_frequency_in_seconds=None, log_retention_hours=None, copy_only=None, windows_host=None, timeout=30)
 ```
 
 ## Arguments
 
-| Name                            | Type | Description                                                                                                                                                                                                                                                | Choices            |
-|---------------------------------|------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|
-| object_name                     | str  | The name of the Rubrik object you wish to assign to an SLA Domain.                                                                                                                                                                                         |                    |
-| sla_name                        | str  | The name of the SLA Domain you wish to assign an object to. To exclude the object from all SLA assignments use `do not protect` as the `sla_name`. To assign the selected object to the SLA of the next higher level object use `clear` as the `sla_name`. |                    |
-| object_type                     | str  | The Rubrik object type you want to assign to the SLA Domain.                                                                                                                                                                                               | vmware, mssql_host |
-| log_backup_frequency_in_seconds | int  | (Optional) The MSSQL Log Backup frequency you'd like to specify with the SLA. Required when the `object_type` is `mssql_host`.                                                                                                                             |                    |
-| log_retention_hours             | int  | (Optional) The MSSQL Log Retention frequency you'd like to specify with the SLA. Required when the `object_type` is `mssql_host`.                                                                                                                          |                    |
-| copy_only                       | bool | (Optional) Take Copy Only Backups with MSSQL. Required when the `object_type` is `mssql_host`.                                                                                                                                                             |                    |
+| Name        | Type        | Description                                                                                                                                                                                                                                                | Choices                          |
+|-------------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------|
+| object_name | str or list | The name of the Rubrik object you wish to assign to an SLA Domain. When the 'object_type' is 'volume_group', the object_name can be a list of volumes.                                                                                                     |                                  |
+| sla_name    | str         | The name of the SLA Domain you wish to assign an object to. To exclude the object from all SLA assignments use `do not protect` as the `sla_name`. To assign the selected object to the SLA of the next higher level object use `clear` as the `sla_name`. |                                  |
+| object_type | str         | The Rubrik object type you want to assign to the SLA Domain.                                                                                                                                                                                               | vmware, mssql_host, volume_group |
+
+
 ## Keyword Arguments
 
-| Name    | Type | Description                                                                                                  | Choices | Default |
-|---------|------|--------------------------------------------------------------------------------------------------------------|---------|---------|
-| timeout | str  | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. |         | 30      |
+| Name                            | Type | Description                                                                                                              | Choices | Default |
+|---------------------------------|------|--------------------------------------------------------------------------------------------------------------------------|---------|---------|
+| log_backup_frequency_in_seconds | int  | The MSSQL Log Backup frequency you'd like to specify with the SLA. Required when the `object_type` is `mssql_host`.      |         | None    |
+| log_retention_hours             | int  | The MSSQL Log Retention frequency you'd like to specify with the SLA. Required when the `object_type` is `mssql_host`.   |         | None    |
+| copy_only                       | bool | Take Copy Only Backups with MSSQL. Required when the `object_type` is `mssql_host`.                                      |         | None    |
+| windows_host                    | str  | The name of the Windows host that contains the relevant volume group. Required when the `object_type` is `volume_group`. |         | None    |
+| timeout                         | str  | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error.             |         | 30      |
 
 ## Returns
 
@@ -27,7 +30,9 @@ def assign_sla(object_name, sla_name, object_type, timeout=30)
 |------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | str  | No change required. The vSphere VM '`object_name`' is already assigned to the '`sla_name`' SLA Domain.                                                                                                                                                                               |
 | str  | No change required. The MSSQL Instance '`object_name`' is already assigned to the '`sla_name`' SLA Domain with the following log settings: log_backup_frequency_in_seconds: `log_backup_frequency_in_seconds`, log_retention_hours: `log_retention_hours` and copy_only: `copy_only` |
+| str  | No change required. The '`object_name`' volume_group is already assigned to the '`sla_name`' SLA Domain.                                                                                                                                                                             |
 | dict | The full API reponse for `POST /internal/sla_domain/{sla_id}/assign`.                                                                                                                                                                                                                |
+| dict | The full API response for `PATCH /internal/volume_group/{id}`.                                                                                                                                                                                                                       |
 
 ## Example
 
@@ -61,4 +66,20 @@ log_retention_hours = 12
 copy_only = False
 
 assignsla = rubrik.assign_sla(object_name, sla_name, object_type, logBackupFrequencyInSeconds, logRetentionHours, copyOnly)
+```
+
+## Volume Group
+
+```py
+import rubrik_cdm
+
+rubrik = rubrik_cdm.Connect()
+
+# Note: To escape the "\" character, you need to use an extra "\". In
+# other words, the "C:\" volume is shown as "C:\\" in the Python code.
+object_name = ["C:\\", "D:\\"]
+windows_host = "windows2016.rubrik.com"
+sla_name = "Gold"
+
+assign_sla = rubrik.assign_sla(object_name, sla_name, "volume_group", windows_host=windows_host)
 ```

--- a/rubrik_cdm/data_management.py
+++ b/rubrik_cdm/data_management.py
@@ -229,7 +229,7 @@ class Data_Management(_API):
 
         Arguments:
             object_name {str} -- The name of the Rubrik object whose ID you wish to lookup.
-            object_type {str} -- The object type you wish to look up. (choices: {vmware, sla, vmware_host, physical_host, fileset_template, managed_volume, aws_native, vcenter})
+            object_type {str} -- The object type you wish to look up. (choices: {vmware, sla, vmware_host, physical_host, fileset_template, managed_volume, mysql_db, mysql_instance, vcenter, ahv, aws_native, oracle_db, windows_host})
             hostname {str} -- The hostname, or one of the hostnames in the cluster, that the Oracle database is running. Required when the object_type is oracle_db.
             timeout {int} -- The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. (default: {15})
 
@@ -249,7 +249,8 @@ class Data_Management(_API):
             'vcenter',
             'ahv',
             'aws_native',
-            'oracle_db']
+            'oracle_db',
+            'windows_host']
 
         if object_type not in valid_object_type:
             raise InvalidParameterException("The object_id() object_type argument must be one of the following: {}.".format(
@@ -314,6 +315,10 @@ class Data_Management(_API):
             "oracle_db": {
                 "api_version": "internal",
                 "api_endpoint": "/oracle/db"
+            },
+            "windows_host": {
+                "api_version": "internal",
+                "api_endpoint": "/volume_group?is_relic=false"
             }
         }
 
@@ -342,6 +347,8 @@ class Data_Management(_API):
             # Define the "object name" to search for
             if object_type == 'physical_host':
                 name_value = filter_field_name
+            elif object_type == "windows_host":
+                name_value = "hostname"
             else:
                 name_value = 'name'
 

--- a/rubrik_cdm/data_management.py
+++ b/rubrik_cdm/data_management.py
@@ -421,7 +421,8 @@ class Data_Management(_API):
                 raise InvalidParameterException(
                     "When the object_type is 'volumge_group' the 'windows_host' paramater must be populated.")
         else:
-            raise InvalidParameterException("The object_name must be a string.")
+            if not isinstance(object_name, (str)):
+                raise InvalidParameterException("The object_name must be a string.")
 
         # Determine if 'do not protect' or 'clear' are the SLA Domain Name
         do_not_protect_regex = re.findall('\\bdo not protect\\b', sla_name, flags=re.IGNORECASE)

--- a/sample/assign_sla.py
+++ b/sample/assign_sla.py
@@ -1,3 +1,5 @@
+# VMware
+
 import rubrik_cdm
 
 rubrik = rubrik_cdm.Connect()
@@ -7,3 +9,38 @@ sla_name = "Gold"
 object_type = "vmware"
 
 assign_sla = rubrik.assign_sla(vm_name, sla_name, object_type)
+
+
+# MSSQL
+
+
+rubrik = rubrik_cdm.Connect()
+
+object_name = 'python-sdk.demo.com'
+object_type = 'mssql_host'
+
+sla_name = 'Gold'
+log_backup_frequency_in_seconds = 600
+log_retention_hours = 12
+copy_only = False
+
+assignsla = rubrik.assign_sla(
+    object_name,
+    sla_name,
+    object_type,
+    logBackupFrequencyInSeconds,
+    logRetentionHours,
+    copyOnly)
+
+# Volume Group
+
+
+rubrik = rubrik_cdm.Connect()
+
+# Note: To escape the "\" character, you need to use an extra "\". In
+# other words, the "C:\" volume is shown as "C:\\" in the Python code.
+object_name = ["C:\\", "D:\\"]
+windows_host = "windows2016.rubrik.com"
+sla_name = "Gold"
+
+assign_sla = rubrik.assign_sla(object_name, sla_name, "volume_group", windows_host=windows_host)

--- a/tests/unit/data_management_test.py
+++ b/tests/unit/data_management_test.py
@@ -1722,7 +1722,7 @@ def test_object_id_invalid_object_type(rubrik):
 
     error_message = error.value.args[0]
 
-    assert error_message == "The object_id() object_type argument must be one of the following: ['vmware', 'sla', 'vmware_host', 'physical_host', 'fileset_template', 'managed_volume', 'mssql_db', 'mssql_instance', 'vcenter', 'ahv', 'aws_native', 'oracle_db']."
+    assert error_message == "The object_id() object_type argument must be one of the following: ['vmware', 'sla', 'vmware_host', 'physical_host', 'fileset_template', 'managed_volume', 'mssql_db', 'mssql_instance', 'vcenter', 'ahv', 'aws_native', 'oracle_db', 'volume_group']."
 
 
 def test_object_id_invalid_fileset_template(rubrik):
@@ -2625,7 +2625,7 @@ def test_assign_sla_invalid_object_type(rubrik):
 
     error_message = error.value.args[0]
 
-    assert error_message == "The assign_sla() object_type argument must be one of the following: ['vmware', 'mssql_host']."
+    assert error_message == "The assign_sla() object_type argument must be one of the following: ['vmware', 'mssql_host', 'volume_group']."
 
 
 def test_assign_sla_idempotence_specific_sla(rubrik, mocker):


### PR DESCRIPTION
# Description

Add support for volume groups in the the `assign_sla` function

## Related Issue

https://github.com/rubrikinc/rubrik-sdk-for-python/issues/125

## How Has This Been Tested?

```
[2019-07-10 16:34:20,378] [DEBUG] -- Node IP: 172.21.8.53
[2019-07-10 16:34:20,380] [DEBUG] -- API Token: ******
[2019-07-10 16:34:20,389] [DEBUG] -- assign_sla: Searching the Rubrik cluster for the SLA Domain 'Gold'.
[2019-07-10 16:34:20,392] [DEBUG] -- object_id: Getting the object id for the sla object 'Gold'.
[2019-07-10 16:34:20,394] [DEBUG] -- Creating the authorization header using the provided API Token.
[2019-07-10 16:34:20,398] [DEBUG] -- GET https://172.21.8.53/api/v1/sla_domain?primary_cluster_id=local&name=Gold
[2019-07-10 16:34:22,477] [DEBUG] -- <Response [200]>

[2019-07-10 16:34:22,478] [DEBUG] -- object_id: Getting the object id for the volume_group object 'am2-drewruss-w1.rubrikdemo.com'.
[2019-07-10 16:34:22,479] [DEBUG] -- Creating the authorization header using the provided API Token.
[2019-07-10 16:34:22,480] [DEBUG] -- GET https://172.21.8.53/api/internal/volume_group?is_relic=false
[2019-07-10 16:34:24,113] [DEBUG] -- <Response [200]>

[2019-07-10 16:34:24,116] [DEBUG] -- cluster_version: Getting the software version of the Rubrik cluster.
[2019-07-10 16:34:24,116] [DEBUG] -- Creating the authorization header using the provided API Token.
[2019-07-10 16:34:24,116] [DEBUG] -- GET https://172.21.8.53/api/v1/cluster/me/version
[2019-07-10 16:34:24,934] [DEBUG] -- <Response [200]>

[2019-07-10 16:34:24,934] [DEBUG] -- object_id: Getting the object id for the physical_host object 'am2-drewruss-w1.rubrikdemo.com'.
[2019-07-10 16:34:24,935] [DEBUG] -- Creating the authorization header using the provided API Token.
[2019-07-10 16:34:24,935] [DEBUG] -- GET https://172.21.8.53/api/v1/host?primary_cluster_id=local&name=am2-drewruss-w1.rubrikdemo.com
[2019-07-10 16:34:25,854] [DEBUG] -- <Response [200]>

[2019-07-10 16:34:25,856] [DEBUG] -- assign_sla: Getting a list of all volumes on the 'am2-drewruss-w1.rubrikdemo.com' Windows host.
[2019-07-10 16:34:25,856] [DEBUG] -- Creating the authorization header using the provided API Token.
[2019-07-10 16:34:25,857] [DEBUG] -- GET https://172.21.8.53/api/internal/host/Host:::51d5324f-df4c-4341-91e8-60a98c640a04/volume
[2019-07-10 16:34:26,787] [DEBUG] -- <Response [200]>

[2019-07-10 16:34:26,789] [DEBUG] -- assign_sla: Getting details of the current volume group on the Windows host.
[2019-07-10 16:34:26,789] [DEBUG] -- Creating the authorization header using the provided API Token.
[2019-07-10 16:34:26,789] [DEBUG] -- GET https://172.21.8.53/api/internal/volume_group/VolumeGroup:::94f48679-847f-47ff-ba55-3f57c10f55b2
[2019-07-10 16:34:28,931] [DEBUG] -- <Response [200]>

[2019-07-10 16:34:28,932] [DEBUG] -- assign_sla: Assigning the vSphere VM '['C:\\', 'E:\\']' to the 'Gold' SLA Domain.
[2019-07-10 16:34:28,932] [DEBUG] -- Creating the authorization header using the provided API Token.
[2019-07-10 16:34:28,932] [DEBUG] -- PATCH https://172.21.8.53/api/internal/volume_group/VolumeGroup:::94f48679-847f-47ff-ba55-3f57c10f55b2
[2019-07-10 16:34:28,933] [DEBUG] -- Config: {"configuredSlaDomainId": "8e6f6618-6af0-4833-a94d-6b32f00ca9b0", "volumeIdsIncludedInSnapshots": ["38d97b53-c3dd-4c92-b910-9ab366907196", "9132428f-47ef-454d-a0e9-19c3a839731c"]}
[2019-07-10 16:34:31,599] [DEBUG] -- <Response [200]>

{'isPaused': False, 'configuredSlaDomainName': 'Gold', 'effectiveSlaDomainId': '8e6f6618-6af0-4833-a94d-6b32f00ca9b0', 'primaryClusterId': '603109f2-eb30-4da8-9389-911d66abb524', 'blackoutWindowStatus': {'isGlobalBlackoutActive': False, 'isSnappableBlackoutActive': False}, 'slaAssignment': 'Direct', 'volumes': [{'naturalId': '\\\\?\\Volume{804fc13a-0000-0000-0000-501f00000000}\\', 'size': 63897071616, 'volumeGroupId': 'VolumeGroup:::94f48679-847f-47ff-ba55-3f57c10f55b2', 'mountPoints': ['C:\\'], 'isCurrentlyPresentOnSystem': True, 'id': '38d97b53-c3dd-4c92-b910-9ab366907196', 'fileSystemType': 'NTFS'}, {'naturalId': '\\\\?\\Volume{520c6bff-2220-4f66-8602-aa532832a731}\\', 'size': 10701762560, 'volumeGroupId': 'VolumeGroup:::94f48679-847f-47ff-ba55-3f57c10f55b2', 'mountPoints': ['E:\\'], 'isCurrentlyPresentOnSystem': True, 'id': '9132428f-47ef-454d-a0e9-19c3a839731c', 'fileSystemType': 'NTFS'}], 'hostId': 'Host:::51d5324f-df4c-4341-91e8-60a98c640a04', 'configuredSlaDomainId': '8e6f6618-6af0-4833-a94d-6b32f00ca9b0', 'effectiveSlaDomainName': 'Gold', 'hostname': 'am2-drewruss-w1.rubrikdemo.com', 'isRelic': False, 'name': 'am2-drewruss-w1.rubrikdemo.com volumes', 'blackoutWindows': {'globalBlackoutWindows': [{'startTime': '2018-11-10T15:13:03+0000', 'endTime': '2018-11-11T10:03:15+0000'}, {'startTime': '2019-04-16T00:05:24+0000', 'endTime': '2019-04-16T01:33:09+0000'}], 'snappableBlackoutWindows': []}, 'id': 'VolumeGroup:::94f48679-847f-47ff-ba55-3f57c10f55b2'}
```

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

