### PR TITLE
Add a method add_nas_share_to_host to add new NAS shares

### DIFF
--- a/docs/add_nas_share_to_host.md
+++ b/docs/add_nas_share_to_host.md
@@ -1,0 +1,51 @@
+# add_physical_host
+
+Add a network share to a host.
+
+```py
+def add_nas_share_to_host(hostname, share_type, export_point, username=None, password=None, domain=None, timeout=60)
+```
+
+## Arguments
+
+| Name         | Type | Description                                                   | Choices  |
+|--------------|------|---------------------------------------------------------------|----------|
+| hostname     | str  | The hostname or IP Address of the host serving the NAS share. |          |
+| share_type   | str  | The type of NAS Share you wish to backup.                     | NFS, SMB |
+| export_point | str  | Name of the share exported by the NAS host.                   |          |
+
+## Keyword Arguments
+
+| Name     | Type | Description                                                                                                  | Choices | Default |
+|----------|------|--------------------------------------------------------------------------------------------------------------|---------|---------|
+| username | str  | Username if the network share requires authentication.                                                       |         | None    |
+| password | str  | Password if the network share requires authentication.                                                       |         | None    |
+| domain   | str  | Domain name of account credentials used for authentication.                                                  |         | None    |
+| timeout  | int  | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. |         | 60      |
+
+## Returns
+
+| Type | Return Value                                                                                   |
+|------|------------------------------------------------------------------------------------------------|
+| str  | No change required. The share with the given hostname and export point has already been added. |
+| dict | The full API response for `POST /internal/host/share` with the given share arguments.          |
+
+## Exceptions
+
+| Type                      | Message                                                                                       |
+|---------------------------|-----------------------------------------------------------------------------------------------|
+| InvalidParameterException | The add_nas_share_to_host() share_type argument must be one of the following: ['NFS', 'SMB']. |
+
+## Example
+
+```py
+import rubrik_cdm
+
+rubrik = rubrik_cdm.Connect()
+
+hostname = "my_nas_host"
+share_type = "NFS" # NFS or SMB
+export_point = "/my_nas_share"
+
+rubrik.add_nas_share_to_host(hostname, share_type, export_point)
+```

--- a/rubrik_cdm/physical.py
+++ b/rubrik_cdm/physical.py
@@ -27,7 +27,7 @@ from .exceptions import InvalidParameterException, InvalidTypeException
 
 
 class Physical(Api):
-    """This class contains methods related to the managment of the Physical objects in the Rubrik cluster."""
+    """This class contains methods related to the management of the Physical objects in the Rubrik cluster."""
 
     def add_physical_host(self, hostname, timeout=60):
         """Add a physical host to the Rubrik cluster.
@@ -255,6 +255,59 @@ class Physical(Api):
 
         self.log("create_fileset: Creating the '{}' Fileset.".format(name))
         return self.post('internal', '/fileset_template/bulk', model, timeout=timeout)
+
+    def add_nas_share_to_host(self, hostname, share_type, export_point, username=None, password=None, domain=None, timeout=60):  # pylint: ignore
+        """Add a network share to a host.
+
+        Arguments:
+            hostname {str} -- The hostname or IP Address of the host serving the NAS share.
+            share_type {str} -- The type of NAS Share you wish to backup. (choices: {NFS, SMB})
+            export_point {str} -- Name of the share exported by the NAS host.
+
+        Keyword Arguments:
+            username {str} -- Username if the network share requires authentication.
+            password {str} -- Password if the network share requires authentication.
+            domain {str} -- Domain name of account credentials used for authentication.
+            timeout {int} -- The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. (default {60})
+
+        Returns:
+            str -- No change required. The share with the given hostname and export point has already been added.
+            dict -- The full API response for `POST /internal/host/share with the given share arguments.
+        """
+        valid_share_type = ['NFS', 'SMB']
+
+        share_address = "{}:{}".format(hostname, export_point)
+
+        if share_type not in valid_share_type:
+            raise InvalidParameterException(
+                "The add_nas_share_to_host() share_type argument must be one of the following: {}.".format(valid_share_type))
+
+        host_id = self.object_id(hostname, 'physical_host')
+
+        self.log("add_nas_share_to_host: Getting the properties of the {} share {}.".format(share_type, share_address))
+        current_host_shares = self.get(
+            'internal', '/host/share?share_type={}&hostid={}'.format(share_type, host_id),
+            timeout=timeout)
+
+        matching_current_host_share = [share_properties for share_properties in current_host_shares['data']
+                                       if share_properties['exportPoint'] == export_point]
+
+        if len(matching_current_host_share) >= 1:
+            return "No change required. The {} share {} is already in Rubrik.".format(share_type, share_address)
+        else:
+            config = {}
+            config['hostId'] = host_id
+            config['shareType'] = share_type
+            config['exportPoint'] = export_point
+            if username:
+                config['username'] = username
+            if password:
+                config['password'] = password
+            if domain:
+                config['domain'] = domain
+
+            self.log("Adding the {} share {} to Rubrik.".format(share_type, share_address))
+            return self.post('internal', '/host/share', config, timeout)
 
     def assign_physical_host_fileset(self, hostname, fileset_name, operating_system, sla_name, include=None, exclude=None, exclude_exception=None, follow_network_shares=False, backup_hidden_folders=False, timeout=30):  # pylint: ignore
         """Assign a Fileset to a Linux or Windows machine. If you have multiple Filesets with identical names, you will need to populate the Filesets properties (i.e this functions keyword arguments)

--- a/rubrik_cdm/physical.py
+++ b/rubrik_cdm/physical.py
@@ -272,7 +272,7 @@ class Physical(Api):
 
         Returns:
             str -- No change required. The share with the given hostname and export point has already been added.
-            dict -- The full API response for `POST /internal/host/share with the given share arguments.
+            dict -- The full API response for `POST /internal/host/share` with the given share arguments.
         """
         valid_share_type = ['NFS', 'SMB']
 

--- a/sample/add_nas_share_to_host.py
+++ b/sample/add_nas_share_to_host.py
@@ -1,0 +1,9 @@
+import rubrik_cdm
+
+rubrik = rubrik_cdm.Connect()
+
+hostname = "my_nas_host"
+share_type = "NFS" # NFS or SMB
+export_point = "/my_nas_share"
+
+rubrik.add_nas_share_to_host(hostname, share_type, export_point)


### PR DESCRIPTION
# Description

Add a method add_nas_share_to_host to the Physical class
    
The add_nas_share_to_host method, given the NAS hostname, share_type (NFS or SMB) and an export point POSTs to /host/share to add the new share to Rubrik. This is done idempotently - if the export point already exists as a share, the function does not POST and returns a string.
    
Also fix a small typo in the docstring of the Physical class.

## Related Issue

https://github.com/rubrikinc/rubrik-sdk-for-python/issues/51

## Motivation and Context

I need a way to add network shares programatically to Rubrik, so that when new shares are defined on my filer, I don't have to manually add them to Rubrik.

## How Has This Been Tested?

Tested on 5.0.1-p1-1342. Checked in the GUI that the share appears as specified and that I can manage protection on it.

Note the use of query parameter `hostid` in the GET /host/share on the internal API version. In the API documentation (https://rubrikinc.github.io/api-doc-internal-5.0/#tag/hostshare), it's `host_id`, but I got a 400 with the underscore in the query parameter name on 5.0.1-p1-1342. Can you test this? Given that the internal endpoint is not versioned, it may be that this has changed between Rubrik versions. Or perhaps the API documentation needs updating.

Includes three unit tests checking addition of a new share, idempotence and that an exception is thrown when the function is passed an invalid share type.

Happy to make whatever changes needed; this function is working for me and I've added all the shares I needed to.

## Screenshots (if appropriate): 

N/A

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/rubrik-sdk-for-python/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
