### PR TITLE
Get Live Mount details and VM names

### DIFF
--- a/docs/get_vsphere_live_mount.md
+++ b/docs/get_vsphere_live_mount.md
@@ -1,0 +1,30 @@
+# get_vsphere_live_mount
+
+Retrieve summary information about Live Mount activity for a VM
+```py
+def get_vsphere_live_mount(vm_name, timeout=15)
+```
+
+## Arguments
+| Name        | Type | Description                                                                 | Choices |
+|-------------|------|-----------------------------------------------------------------------------|---------|
+| vm_name  | str  | The name of the mounted vSphere VM. |         |
+## Keyword Arguments
+| Name        | Type | Description                                                                 | Choices | Default |
+|-------------|------|-----------------------------------------------------------------------------|---------|---------|
+| timeout  | int  | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error.  |         |    15     |
+
+## Returns
+| Type | Return Value                                                                                   |
+|------|-----------------------------------------------------------------------------------------------|
+| dict  | The full response of `GET /v1/vmware/vm/snapshot/mount?vm_id={}`. |
+## Example
+```py
+import rubrik_cdm
+
+rubrik = rubrik_cdm.Connect()
+
+vm_name = "python-sdk-demo"
+
+live_mount = rubrik.get_vsphere_live_mount(vm_name)
+```

--- a/docs/get_vsphere_live_mount_names.md
+++ b/docs/get_vsphere_live_mount_names.md
@@ -1,0 +1,30 @@
+# get_vsphere_live_mount_names
+
+Retrieve existing Live Mount VM name(s) for a vSphere VM.
+```py
+def get_vsphere_live_mount_names(vm_name, timeout=15)
+```
+
+## Arguments
+| Name        | Type | Description                                                                 | Choices |
+|-------------|------|-----------------------------------------------------------------------------|---------|
+| vm_name  | str  | The name of the mounted vSphere VM. |         |
+## Keyword Arguments
+| Name        | Type | Description                                                                 | Choices | Default |
+|-------------|------|-----------------------------------------------------------------------------|---------|---------|
+| timeout  | int  | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error.  |         |    15     |
+
+## Returns
+| Type | Return Value                                                                                   |
+|------|-----------------------------------------------------------------------------------------------|
+| list  | A list of the Live Mounted VM names. |
+## Example
+```py
+import rubrik_cdm
+
+rubrik = rubrik_cdm.Connect()
+
+vm_name = "python-sdk-demo"
+
+live_mount = rubrik.get_vsphere_live_mount_names(vm_name)
+```

--- a/rubrik_cdm/data_management.py
+++ b/rubrik_cdm/data_management.py
@@ -1438,11 +1438,6 @@ class Data_Management(_API):
         self.log("get_vsphere_live_mount: Searching the Rubrik cluster for the mounted vSphere VM '{}'.".format(vm_name))
         vm_id = self.object_id(vm_name, 'vmware', timeout=timeout)
 
-        #try:
-        #    vm_id
-        #except NameError:
-        #    raise InvalidParameterException("The vSphere VM '{}' does not exit.".format(vm_name))
-        #else:
         self.log("get_vsphere_live_mount: Getting Live Mounts of vSphere VM {}.".format(vm_name))
         return self.get('v1', '/vmware/vm/snapshot/mount?vm_id={}'.format(vm_id), timeout)
     

--- a/rubrik_cdm/data_management.py
+++ b/rubrik_cdm/data_management.py
@@ -1450,7 +1450,7 @@ class Data_Management(_API):
         """Get existing Live Mount VM name(s) for a vSphere VM.
 
         Arguments:
-            vm_name {str} -- The name of the mounted vSphere VM (source).
+            vm_name {str} -- The name of the mounted vSphere VM.
 
         Keyword Arguments:
             timeout {int} -- The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. (default: {15})

--- a/sample/get_vsphere_live_mount.py
+++ b/sample/get_vsphere_live_mount.py
@@ -1,0 +1,7 @@
+import rubrik_cdm
+
+vm_name = "python-sdk-demo"
+
+rubrik = rubrik_cdm.Connect()
+
+live_mount = rubrik.get_vsphere_live_mount(vm_name)

--- a/sample/get_vsphere_live_mount_names.py
+++ b/sample/get_vsphere_live_mount_names.py
@@ -1,0 +1,7 @@
+import rubrik_cdm
+
+vm_name = "python-sdk-demo"
+
+rubrik = rubrik_cdm.Connect()
+
+live_mount = rubrik.get_vsphere_live_mount_names(vm_name)


### PR DESCRIPTION
# Description

Get the VM details and names of vSphere live mounts.

## Related Issue

https://github.com/rubrikinc/rubrik-sdk-for-python/issues/74

## Motivation and Context

Live mounts don't return mounted vm names. These functions will help retrieve details and names of the VMs

## How Has This Been Tested?

Tested locally with gaia.

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/rubrik-sdk-for-python/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
