### PR TITLE
Add support for PUT API calls

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,16 @@ password = "RubrikPythonSDK"
 rubrik = rubrik_cdm.Connect(node_ip, username, password)
 ```
 
+```py
+import rubrik_cdm
+
+node_ip = "172.21.8.90"
+username = "sdk@rangers.lab"
+api_token "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUVkN2FhYzlfZWU0MzA5ODQtMGE1Zi00NGZjLTliNTYtN"
+
+rubrik = rubrik_cdm.Connect(node_ip, username, api_token=api_token)
+```
+
 
 ## Debug
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -10,6 +10,7 @@
 * [job_status](job_status.md)
 * [patch](patch.md)
 * [post](post.md)
+* [put](put.md)
 
 ### Bootstrap Functions
 * [setup_cluster](setup_cluster.md)

--- a/docs/put.md
+++ b/docs/put.md
@@ -1,0 +1,41 @@
+# put
+
+Send a PUT request to the provided Rubrik API endpoint.
+```py
+def put(api_version, api_endpoint, config, timeout=15, authentication=True)
+```
+
+## Arguments
+| Name         | Type | Description                                                   | Choices          |
+|--------------|------|---------------------------------------------------------------|------------------|
+| api_version  | str  | The version of the Rubrik CDM API to call.                    | v1, v2, internal |
+| api_endpoint | str  | The endpoint of the Rubrik CDM API to call (ex. /cluster/me). |                  |
+| config       | dict | The specified data to send with the API call.                 |                  |
+## Keyword Arguments
+| Name           | Type | Description                                                                                                  | Choices | Default |
+|----------------|------|--------------------------------------------------------------------------------------------------------------|---------|---------|
+| timeout        | int  | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. |         | 15      |
+| authentication | bool | Flag that specifies whether or not to utilize authentication when making the API call.                       |         | True    |
+
+## Returns
+| Type | Return Value                       |
+|------|------------------------------------|
+| dict | The response body of the API call. |
+## Example
+## Example
+```py
+import rubrik_cdm
+
+rubrik = rubrik_cdm.Connect()
+
+
+config = {}
+config['loginBanner'] = "Login Banner for the Python SDK Cluster"
+
+
+set_login_banner = rubrik.put('internal', '/cluster/me/login_banner', config)
+```
+
+
+
+

--- a/rubrik_cdm/api.py
+++ b/rubrik_cdm/api.py
@@ -112,6 +112,13 @@ class Api():
                 self.log('PATCH {}'.format(request_url))
                 self.log('Config: {}'.format(config))
                 api_request = requests.patch(request_url, verify=False, headers=header, data=config, timeout=timeout)
+            elif call_type == 'PUT':
+                config = json.dumps(config)
+                request_url = "https://{}/api/{}{}".format(
+                    self.node_ip, api_version, api_endpoint)
+                self.log('PUT {}'.format(request_url))
+                self.log('Config: {}'.format(config))
+                api_request = requests.put(request_url, verify=False, headers=header, data=config, timeout=timeout)
             elif call_type == 'DELETE':
                 config = json.dumps(config)
                 request_url = "https://{}/api/{}{}".format(
@@ -237,6 +244,31 @@ class Api():
 
         return self._common_api(
             'PATCH',
+            api_version,
+            api_endpoint,
+            config=config,
+            job_status_url=None,
+            timeout=timeout,
+            authentication=authentication)
+
+    def put(self, api_version, api_endpoint, config, timeout=15, authentication=True):
+        """Send a PUT request to the provided Rubrik API endpoint.
+
+        Arguments:
+            api_version {str} -- The version of the Rubrik CDM API to call. (choices: {v1, v2, internal})
+            api_endpoint {str} -- The endpoint of the Rubrik CDM API to call (ex. /cluster/me).
+            config {dict} -- The specified data to send with the API call.
+
+        Keyword Arguments:
+            timeout {int} -- The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. (default: {15})
+            authentication {bool} -- Flag that specifies whether or not to utilize authentication when making the API call. (default: {True})
+
+        Returns:
+            dict -- The response body of the API call.
+        """
+
+        return self._common_api(
+            'PUT',
             api_version,
             api_endpoint,
             config=config,


### PR DESCRIPTION
# Description

* adds support for PUT API calls
* adds an example of using an API Token for authentication

## Motivation and Context

There are a few PUT calls in `/internal/cluster`

## How Has This Been Tested?

* Manual testing in lab

