### PR TITLE
cdm vcenter refresh a single vm metadata, add fileset object type to assign_sla.py

### DIFF
--- a/docs/add_host_share.md
+++ b/docs/add_host_share.md
@@ -1,0 +1,38 @@
+# add_host_share
+
+Add a network share object to a host.
+```py
+def def add_host_share(self, hostname, share_type, export_point, username=None, password=None, domain=None, timeout=60)
+```
+
+## Arguments
+| Name             | Type | Description                                            | Choices |
+|------------------|------|--------------------------------------------------------|---------|
+| hostname       | str  | The hostname or IP Address of the physical host you want to add to the Rubrik cluster. |         |
+| share_type     | str  | The share object type to be added to the host. (choices: {NFS, SMB})    |         |
+| export_point | str  | The NFS export path of the share.     |         |
+## Keyword Arguments
+| Name           | Type | Description                                                                                                  | Choices | Default |
+|----------------|------|--------------------------------------------------------------------------------------------------------------|---------|---------|
+| username       | str  | The username for the host.                                                                                   |         | None    |
+| password       | str  | The password for the host.                                                                                   |         | None    |
+| domain         | str  | The domain for the host                                                                                      |         | None    |
+| timeout        | int  | The number of seconds to wait to establish a connection with the Rubrik cluster before returning a timeout error. |         | 60      |
+
+## Returns
+| Type  | Return Value                                                                                                                                                                                     |
+|-------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| dict  | The full API response for `POST /internal/host/share` |
+
+## Example
+```py
+import rubrik_cdm
+
+hostname = 'nas-server.rubrikdemo.com'
+share_type = 'NFS'
+export_point = '/nas_share'
+
+rubrik = rubrik_cdm.Connect()
+
+add_host_share = rubrik.add_host_share(hostname, share_type, export_point)
+```

--- a/docs/assign_sla.md
+++ b/docs/assign_sla.md
@@ -22,6 +22,8 @@ def assign_sla(self, object_name, sla_name, object_type, log_backup_frequency_in
 | log_retention_hours             | int  | The MSSQL Log Retention frequency you'd like to specify with the SLA. Required when the `object_type` is `mssql_host`.   |         | None    |
 | copy_only                       | bool | Take Copy Only Backups with MSSQL. Required when the `object_type` is `mssql_host`.                                      |         | None    |
 | windows_host                    | str  | The name of the Windows host that contains the relevant volume group. Required when the `object_type` is `volume_group`. |         | None    |
+| nas_host                    | str  | The name of the NAS host that contains the relevant share. Required when the `object_type` is `fileset`. |         | None    |
+| share                    | str  | The name of the network share a fileset will be created for. Required when the `object_type` is `fileset`. |         | None    |
 | timeout                         | str  | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error.             |         | 30      |
 
 ## Returns
@@ -82,4 +84,21 @@ windows_host = "windows2016.rubrik.com"
 sla_name = "Gold"
 
 assign_sla = rubrik.assign_sla(object_name, sla_name, "volume_group", windows_host=windows_host)
+```
+
+## Fileset
+
+```py
+import rubrik_cdm
+
+rubrik = rubrik_cdm.Connect()
+
+object_name = 'nas_fileset'
+object_type = 'fileset'
+
+sla_name = 'Gold'
+nas_host = 'nas-server.rubrik.com'
+share = '/nas_share'
+
+assign_sla = rubrik.assign_sla(object_name, sla_name, object_type, nas_host=nas_host, share=share)
 ```

--- a/docs/vcenter_refresh_vm.md
+++ b/docs/vcenter_refresh_vm.md
@@ -1,0 +1,30 @@
+# vcenter_refresh_vm
+
+Refresh a single vSphere VM metadata.
+```py
+def vcenter_refresh_vm(vm_name, timeout=15)
+```
+
+## Arguments
+| Name        | Type | Description                                                                 | Choices |
+|-------------|------|-----------------------------------------------------------------------------|---------|
+| vm_name  | str  | The name of the vSphere VM. |         |
+## Keyword Arguments
+| Name        | Type | Description                                                                 | Choices | Default |
+|-------------|------|-----------------------------------------------------------------------------|---------|---------|
+| timeout  | int  | The number of seconds to wait to establish a connection with the Rubrik cluster before returning a timeout error.  |         |    15     |
+
+## Returns
+| Type | Return Value                                                                                   |
+|------|-----------------------------------------------------------------------------------------------|
+|   | No content. |
+## Example
+```py
+import rubrik_cdm
+
+rubrik = rubrik_cdm.Connect()
+
+vm_name = "python-sdk-demo"
+
+rubrik.vcenter_refresh_vm(vm_name)
+```

--- a/rubrik_cdm/data_management.py
+++ b/rubrik_cdm/data_management.py
@@ -398,6 +398,8 @@ class Data_Management(_API):
             log_retention_hours {int} -- The MSSQL Log Retention frequency you'd like to specify with the SLA. Required when the `object_type` is `mssql_host`. (default {None})
             copy_only {int} -- Take Copy Only Backups with MSSQL. Required when the `object_type` is `mssql_host`. (default {None})
             windows_host {str} -- The name of the Windows host that contains the relevant volume group. Required when the `object_type` is `volume_group`. (default {None})
+            nas_host {str} -- The name of the NAS host that contains the relevant share. Required when the `object_type` is `fileset`. (default {None})
+            share {str} -- The name of the network share a fileset will be created for. Required when the `object_type` is `fileset`. (default {None})
             timeout {bool} -- The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. (default: {30})
 
         Returns:

--- a/rubrik_cdm/physical.py
+++ b/rubrik_cdm/physical.py
@@ -426,3 +426,33 @@ class Physical(Api):
         elif current_fileset['total'] == 1 and current_fileset['data'][0]['configuredSlaDomainId'] == sla_id:
             return "No change required. The {} Fileset '{}' is already assigned to the SLA Domain '{}' on the physical host '{}'.".format(
                 operating_system, fileset_name, sla_name, hostname)
+
+    def add_host_share(self, hostname, share_type, export_point, username=None, password=None, domain=None, timeout=60):
+        """Add a network share object to a host.
+        Arguments:
+            hostname {str} -- The hostname or IP Address of the physical host you want to add to the Rubrik cluster.
+            share_type {str} -- The share object type to be added to the host. (choices: {NFS, SMB})
+            export_point {str} -- The NFS export path of the share. 
+        Keyword Arguments:
+            username {str} -- The username for the host. (default: {None})
+            password {str} -- The password for the host. (default: {None})
+            domain {str} -- The domain for the host (default: {None})
+            timeout {int} -- The number of seconds to wait to establish a connection with the Rubrik cluster before returning a timeout error. (default: {60})
+        Returns:
+            dict -- The full API response for `POST /internal/host/share`.
+        """
+        if(len(hostname) == 0 or len(share_type) == 0 or len(export_point) == 0):
+            raise InvalidParameterException("The provided hostname list, share_type, export_point is empty.")
+        self.log('Searching the Rubrik cluster for the host ID.')
+        host_id = self.object_id(hostname, 'physical_host', timeout=timeout)
+
+        config = {}
+        config['hostname'] = hostname
+        config['hostId'] = host_id
+        config['shareType'] = share_type
+        config['exportPoint'] = export_point
+        config['username'] = username
+        config['password'] = password
+        config['domain'] = domain
+        self.log("add_host_share: Adding share object '{}' to Physical Host ID {}".format(export_point, host_id))
+        return self.post('internal', '/host/share', config, timeout)

--- a/sample/add_host_share.py
+++ b/sample/add_host_share.py
@@ -1,0 +1,9 @@
+import rubrik_cdm
+
+hostname = 'nas-server.rubrikdemo.com'
+share_type = 'NFS'
+export_point = '/nas_share'
+
+rubrik = rubrik_cdm.Connect()
+
+add_host_share = rubrik.add_host_share(hostname, share_type, export_point)

--- a/sample/assign_sla.py
+++ b/sample/assign_sla.py
@@ -32,6 +32,7 @@ assignsla = rubrik.assign_sla(
     logRetentionHours,
     copyOnly)
 
+
 # Volume Group
 
 
@@ -44,3 +45,18 @@ windows_host = "windows2016.rubrik.com"
 sla_name = "Gold"
 
 assign_sla = rubrik.assign_sla(object_name, sla_name, "volume_group", windows_host=windows_host)
+
+
+# Fileset
+
+
+rubrik = rubrik_cdm.Connect()
+
+object_name = 'nas_fileset'
+object_type = 'fileset'
+
+sla_name = 'Gold'
+nas_host = 'nas-server.rubrik.com'
+share = '/nas_share'
+
+assign_sla = rubrik.assign_sla(object_name, sla_name, object_type, nas_host=nas_host, share=share)

--- a/sample/vcenter_refresh_vm.py
+++ b/sample/vcenter_refresh_vm.py
@@ -1,0 +1,7 @@
+import rubrik_cdm
+
+rubrik = rubrik_cdm.Connect()
+
+vm_name = "python-sdk-demo"
+
+rubrik.vcenter_refresh_vm(vm_name)

--- a/tests/unit/data_management_test.py
+++ b/tests/unit/data_management_test.py
@@ -2625,7 +2625,7 @@ def test_assign_sla_invalid_object_type(rubrik):
 
     error_message = error.value.args[0]
 
-    assert error_message == "The assign_sla() object_type argument must be one of the following: ['vmware', 'mssql_host', 'volume_group']."
+    assert error_message == "The assign_sla() object_type argument must be one of the following: ['vmware', 'mssql_host', 'volume_group', 'fileset']."
 
 
 def test_assign_sla_idempotence_specific_sla(rubrik, mocker):


### PR DESCRIPTION
# Description

- Refresh a single VM metadata from vcenter
- Added fileset object type to assign_sla function
- Add share object to host
`assign_sla`
`add_host_share`
`vcenter_refresh_vm`

## Related Issue

https://github.com/rubrikinc/rubrik-sdk-for-python/issues/120

## Motivation and Context

Speed up refresh time and limit the scope to a single VM
Filesets for host object shares assigned an SLA with the existing assign_sla function

## How Has This Been Tested?

Locally on gaia

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/rubrik-sdk-for-python/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
