### PR TITLE
Add AHV support to assign_sla

### DIFF
--- a/docs/assign_sla.md
+++ b/docs/assign_sla.md
@@ -7,11 +7,11 @@ def assign_sla(self, object_name, sla_name, object_type, log_backup_frequency_in
 
 ## Arguments
 
-| Name        | Type        | Description                                                                                                                                                                                                                                                | Choices                          |
-|-------------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------|
-| object_name | str or list | The name of the Rubrik object you wish to assign to an SLA Domain. When the 'object_type' is 'volume_group', the object_name can be a list of volumes.                                                                                                     |                                  |
-| sla_name    | str         | The name of the SLA Domain you wish to assign an object to. To exclude the object from all SLA assignments use `do not protect` as the `sla_name`. To assign the selected object to the SLA of the next higher level object use `clear` as the `sla_name`. |                                  |
-| object_type | str         | The Rubrik object type you want to assign to the SLA Domain.                                                                                                                                                                                               | vmware, mssql_host, volume_group |
+| Name        | Type        | Description                                                                                                                                                                                                                                                | Choices                               |
+|-------------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------|
+| object_name | str or list | The name of the Rubrik object you wish to assign to an SLA Domain. When the 'object_type' is 'volume_group', the object_name can be a list of volumes.                                                                                                     |                                       |
+| sla_name    | str         | The name of the SLA Domain you wish to assign an object to. To exclude the object from all SLA assignments use `do not protect` as the `sla_name`. To assign the selected object to the SLA of the next higher level object use `clear` as the `sla_name`. |                                       |
+| object_type | str         | The Rubrik object type you want to assign to the SLA Domain.                                                                                                                                                                                               | vmware, mssql_host, volume_group, ahv |
 
 
 ## Keyword Arguments
@@ -82,4 +82,18 @@ windows_host = "windows2016.rubrik.com"
 sla_name = "Gold"
 
 assign_sla = rubrik.assign_sla(object_name, sla_name, "volume_group", windows_host=windows_host)
+```
+
+## AHV
+
+```py
+import rubrik_cdm
+
+rubrik = rubrik_cdm.Connect()
+
+
+vm_name = "python-sdk-demo"
+sla_name = "Gold"
+
+assign_sla = rubrik.assign_sla(object_name, sla_name, "ahv")
 ```

--- a/rubrik_cdm/data_management.py
+++ b/rubrik_cdm/data_management.py
@@ -33,7 +33,7 @@ _API = Api
 class Data_Management(_API):
     """This class contains methods related to backup and restore operations for the various objects managed by the Rubrik cluster."""
 
-    def on_demand_snapshot(self, object_name, object_type, sla_name='current', fileset=None, host_os=None, sql_host=None, sql_instance=None, sql_db=None, hostname=None, force_full=False,  timeout=15):  # pylint: ignore
+    def on_demand_snapshot(self, object_name, object_type, sla_name='current', fileset=None, host_os=None, sql_host=None, sql_instance=None, sql_db=None, hostname=None, force_full=False, timeout=15):  # pylint: ignore
         """Initiate an on-demand snapshot.
 
         Arguments:
@@ -364,7 +364,8 @@ class Data_Management(_API):
             for item in api_request['data']:
                 if object_type == 'oracle_db':
                     # Find the oracle_db object with the correct hostName or RAC cluster name. Checks the instances for a match, set the host_match flag if matched.
-                    # Instance names can be stored/entered with and without the domain name so we will compare the hostname with the domain.
+                    # Instance names can be stored/entered with and without the domain name so
+                    # we will compare the hostname with the domain.
                     for instance in item['instances']:
                         if hostname.split('.')[0] in instance['hostName'] and not host_match:
                             object_ids.append(item['id'])
@@ -416,7 +417,6 @@ class Data_Management(_API):
         """
 
         valid_object_type = ['vmware', 'mssql_host', 'volume_group', 'fileset', 'ahv']
-
 
         if object_type not in valid_object_type:
             raise InvalidParameterException(
@@ -474,7 +474,7 @@ class Data_Management(_API):
                 config['managedIds'] = [vm_id]
 
                 return self.post("internal", "/sla_domain/{}/assign".format(sla_id), config, timeout)
-        
+
         elif object_type == 'fileset':
             self.log("assign_sla: Searching the Rubrik cluster for the NAS host '{}'.".format(nas_host))
             host_id = self.object_id(nas_host, 'physical_host', timeout=timeout)
@@ -486,7 +486,9 @@ class Data_Management(_API):
                 if shares['hostId'] == host_id and shares['exportPoint'] == share:
                     share_id = shares['id']
             if share_id is None:
-                raise InvalidParameterException("The share object'{}' does not exist for host '{}'.".format(share, nas_host))
+                raise InvalidParameterException(
+                    "The share object'{}' does not exist for host '{}'.".format(
+                        share, nas_host))
 
             self.log("assign_sla: Searching the Rubrik cluster for the fileset '{}' template.".format(object_name))
             fileset_summary = self.get("v1", '/fileset?is_relic=false&name={}'.format(object_name), timeout=timeout)
@@ -509,7 +511,7 @@ class Data_Management(_API):
             if sla_id == fileset_summary['data'][0]['configuredSlaDomainId']:
                 return "No change required. The NAS fileset '{}' is already assigned to the '{}' SLA Domain.".format(
                     object_name, sla_name)
-            
+
             else:
                 self.log("assign_sla: Assigning the fileset '{}' to the '{}' SLA Domain.".format(object_name, sla_name))
 
@@ -526,7 +528,7 @@ class Data_Management(_API):
             vm_summary = self.get('internal', '/nutanix/vm/{}'.format(vm_id), timeout=timeout)
 
             if sla_id == vm_summary['configuredSlaDomainId']:
-                return "No change required. The vSphere VM '{}' is already assigned to the '{}' SLA Domain.".format(
+                return "No change required. The AHV VM '{}' is already assigned to the '{}' SLA Domain.".format(
                     object_name, sla_name)
             else:
                 self.log("assign_sla: Assigning the AHV VM '{}' to the '{}' SLA Domain.".format(object_name, sla_name))
@@ -1653,10 +1655,10 @@ class Data_Management(_API):
         else:
             vcenter_id = data['data'][0]['infraPath'][0]['id']
             vm_id = data['data'][0]['id']
-        
+
         self.log("vcenter_refresh_vm: Getting the MOID for vSphere VM {}.".format(vm_name))
         split_moid = vm_id.split('-')
-        moid = split_moid[-2]+'-'+split_moid[-1]
-        config = {'vmMoid':moid}
+        moid = split_moid[-2] + '-' + split_moid[-1]
+        config = {'vmMoid': moid}
         self.log("vcenter_refresh_vm: Refreshing vSphere VM {} metadata.".format(vm_name))
         self.post('internal', '/vmware/vcenter/{}/refresh_vm'.format(vcenter_id), config, timeout)

--- a/rubrik_cdm/data_management.py
+++ b/rubrik_cdm/data_management.py
@@ -667,7 +667,7 @@ class Data_Management(_API):
 
         Keyword Arguments:
             date {str} -- The date of the snapshot you wish to Live Mount formated as `Month-Day-Year` (ex: 1-15-2014). If `latest` is specified, the last snapshot taken will be used. (default: {'latest'})
-            time {str} -- The time of the snapshot you wish to Live Mount formated formated as `Hour:Minute AM/PM` (ex: 1:30 AM). If `latest` is specified, the last snapshot taken will be used. (default: {'latest'})
+            time {str} -- The time of the snapshot you wish to Live Mount formated as `Hour:Minute AM/PM` (ex: 1:30 AM). If `latest` is specified, the last snapshot taken will be used. (default: {'latest'})
             host {str} -- The hostname or IP address of the ESXi host to Live Mount the VM on. By default, the current host will be used. (default: {'current'})
             remove_network_devices {bool} -- Flag that determines whether to remove the network interfaces from the Live Mounted VM. Set to `True` to remove all network interfaces. (default: {False})
             power_on {bool} -- Flag that determines whether the VM should be powered on after the Live Mount. Set to `True` to power on the VM. Set to `False` to mount the VM but not power it on. (default: {True})
@@ -740,7 +740,7 @@ class Data_Management(_API):
 
         Keyword Arguments:
             date {str} -- The date of the snapshot you wish to Instantly Recover formated as `Month-Day-Year` (ex: 1-15-2014). If 'latest' is specified, the last snapshot taken will used. (default: {'latest'})
-            time {str} -- The time of the snapshot you wish to Instantly Recover formated formated as `Hour:Minute AM/PM`  (ex: 1:30 AM). If 'latest' is specified, the last snapshot taken will be used. (default: {'latest'})
+            time {str} -- The time of the snapshot you wish to Instantly Recover formated as `Hour:Minute AM/PM`  (ex: 1:30 AM). If 'latest' is specified, the last snapshot taken will be used. (default: {'latest'})
             host {str} -- The hostname or IP address of the ESXi host to Instantly Recover the VM on. By default, the current host will be used. (default: {'current'})
             remove_network_devices {bool} -- Flag that determines whether to remove the network interfaces from the Instantly Recovered VM. Set to `True` to remove all network interfaces. (default: {False})
             power_on {bool} -- Flag that determines whether the VM should be powered on after Instant Recovery. Set to `True` to power on the VM. Set to `False` to instantly recover the VM but not power it on. (default: {True})
@@ -1314,7 +1314,7 @@ class Data_Management(_API):
         Arguments:
             db_name {str} -- The name of the database to Live Mount.
             date {str} -- The recovery_point date to recovery to formated as `Month-Day-Year` (ex: 1-15-2014).
-            time {str} -- The recovery_point time to recovery to formated formated as `Hour:Minute AM/PM` (ex: 1:30 AM).
+            time {str} -- The recovery_point time to recovery to formated as `Hour:Minute AM/PM` (ex: 1:30 AM).
 
         Keyword Arguments:
             sql_instance {str} -- The SQL instance name with the database you wish to Live Mount.
@@ -1597,7 +1597,7 @@ class Data_Management(_API):
         Arguments:
             db_name {str} -- The name of the database to instantly recover.
             date {str} -- The recovery_point date to recover to formated as `Month-Day-Year` (ex: 1-15-2014).
-            time {str} -- The recovery_point time to recover to formated formated as `Hour:Minute AM/PM` (ex: 1:30 AM).
+            time {str} -- The recovery_point time to recover to formated as `Hour:Minute AM/PM` (ex: 1:30 AM).
 
         Keyword Arguments:
             sql_instance {str} -- The SQL instance name with the database to instantly recover.

--- a/tests/unit/data_management_test.py
+++ b/tests/unit/data_management_test.py
@@ -2625,7 +2625,7 @@ def test_assign_sla_invalid_object_type(rubrik):
 
     error_message = error.value.args[0]
 
-    assert error_message == "The assign_sla() object_type argument must be one of the following: ['vmware', 'mssql_host', 'volume_group', 'fileset']."
+    assert error_message == "The assign_sla() object_type argument must be one of the following: ['vmware', 'mssql_host', 'volume_group', 'fileset', 'ahv']."
 
 
 def test_assign_sla_idempotence_specific_sla(rubrik, mocker):

--- a/tests/unit/data_management_test.py
+++ b/tests/unit/data_management_test.py
@@ -2625,7 +2625,7 @@ def test_assign_sla_invalid_object_type(rubrik):
 
     error_message = error.value.args[0]
 
-    assert error_message == "The assign_sla() object_type argument must be one of the following: ['vmware', 'mssql_host', 'volume_group']."
+    assert error_message == "The assign_sla() object_type argument must be one of the following: ['vmware', 'mssql_host', 'volume_group', 'ahv']."
 
 
 def test_assign_sla_idempotence_specific_sla(rubrik, mocker):


### PR DESCRIPTION
# Description

Add the ability to assign and SLA to an AHV VM.

## Related Issue

https://github.com/rubrikinc/rubrik-modules-for-ansible/issues/59

## How Has This Been Tested?

```
[2019-09-23 16:28:58,275] [DEBUG] -- Node IP: shrd1-rbk01.rubrikdemo.com
[2019-09-23 16:28:58,275] [DEBUG] -- Username: drew.russell@rubrikdemo.com
[2019-09-23 16:28:58,275] [DEBUG] -- Password: ******
[2019-09-23 16:28:58,275] [DEBUG] -- assign_sla: Searching the Rubrik cluster for the SLA Domain 'Gold'.
[2019-09-23 16:28:58,276] [DEBUG] -- object_id: Getting the object id for the sla object 'Gold'.
[2019-09-23 16:28:58,276] [DEBUG] -- GET https://shrd1-rbk01.rubrikdemo.com/api/v1/sla_domain?primary_cluster_id=local&name=Gold
[2019-09-23 16:28:59,471] [DEBUG] -- <Response [200]>

[2019-09-23 16:28:59,471] [DEBUG] -- assign_sla: Searching the Rubrik cluster for the AHV VM 'AHVExport'.
[2019-09-23 16:28:59,471] [DEBUG] -- object_id: Getting the object id for the ahv object 'AHVExport'.
[2019-09-23 16:28:59,471] [DEBUG] -- GET https://shrd1-rbk01.rubrikdemo.com/api/internal/nutanix/vm?primary_cluster_id=local&is_relic=false&name=AHVExport
[2019-09-23 16:29:00,560] [DEBUG] -- <Response [200]>

[2019-09-23 16:29:00,561] [DEBUG] -- assign_sla: Determing the SLA Domain currently assigned to the AHV VM 'AHVExport'.
[2019-09-23 16:29:00,561] [DEBUG] -- GET https://shrd1-rbk01.rubrikdemo.com/api/internal/nutanix/vm/NutanixVirtualMachine:::a2728450-f471-4b56-8643-5789f9f36b49-vm-d882fd46-e9ce-4bdd-bb9e-24baab7fe34b
[2019-09-23 16:29:01,623] [DEBUG] -- <Response [200]>

[2019-09-23 16:29:01,623] [DEBUG] -- assign_sla: Assigning the AHV VM 'AHVExport' to the 'Gold' SLA Domain.
[2019-09-23 16:29:01,623] [DEBUG] -- POST https://shrd1-rbk01.rubrikdemo.com/api/internal/sla_domain/41f69fcb-d316-4c75-b63a-a2ad0596d17f/assign
[2019-09-23 16:29:01,623] [DEBUG] -- Config: {"managedIds": ["NutanixVirtualMachine:::a2728450-f471-4b56-8643-5789f9f36b49-vm-d882fd46-e9ce-4bdd-bb9e-24baab7fe34b"]}
[2019-09-23 16:29:03,905] [DEBUG] -- Response: 
[2019-09-23 16:29:03,906] [DEBUG] -- <Response [204]>

{'status_code': 204}
```

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

