### PR TITLE
added NAS share to on_demand_snapshot

### DIFF
--- a/docs/on_demand_snapshot.md
+++ b/docs/on_demand_snapshot.md
@@ -2,7 +2,7 @@
 
 Initiate an on-demand snapshot.
 ```py
-def on_demand_snapshot(object_name, object_type, sla_name='current', fileset=None, host_os=None, sql_host=None, sql_instance=None, sql_db=None, timeout=15)
+def on_demand_snapshot(object_name, object_type, sla_name='current', fileset=None, host_os=None, sql_host=None, sql_instance=None, sql_db=None, hostname=None, force_full=False, share_type=None, timeout=15)
 ```
 
 ## Arguments
@@ -14,13 +14,14 @@ def on_demand_snapshot(object_name, object_type, sla_name='current', fileset=Non
 | Name         | Type | Description                                                                                                                             | Choices        | Default |
 |--------------|------|-----------------------------------------------------------------------------------------------------------------------------------------|----------------|---------|
 | sla_name     | str  | The SLA Domain name you want to assign the on-demand snapshot to. By default, the currently assigned SLA Domain will be used.           |                | current |
-| fileset      | str  | The name of the Fileset you wish to backup. Only required when taking a on-demand snapshot of a physical host.                          |                | None    |
+| fileset      | str  | The name of the Fileset you wish to backup. Only required when taking a on-demand snapshot of a physical host or share.                 |                | None    |
 | host_os      | str  | The operating system for the physical host. Only required when taking a on-demand snapshot of a physical host.                          | Linux, Windows | None    |
 | sql_host     | str  | The name of the SQL Host hosting the specified database. Only required when taking a on-demand snapshot of a MSSQL DB.                  | None           | None    |
 | sql_instance | str  | The name of the SQL Instance hosting the specified database. Only required when taking a on-demand snapshot of a MSSQL DB.              | None           | None    |
 | sql_db       | str  | TThe name of the SQL DB. Only required when taking a on-demand snapshot of a MSSQL DB.                                                  | None           | None    |
-| hostname     | str  | The host name, or one of the host names in the cluster, that the Oracle database is running. Required when the object_type is oracle_db | None           | None    |
+| hostname     | str  | The host name, or one of the host names in the cluster, that the Oracle database is running or the NAS server hostname. Required when the object_type is oracle_db or share. | None           | None    |
 | force_full   | bool | If True will force a new full image backup of an Oracle database. Used when the object_type is oracle_db                                | True, False    | False   |
+| share_type   | str  | The type of NAS share i.e. NFS or SMB. Only required when taking a snapshot of a Share.                                                 | True, False    | False   |
 | timeout      | int  | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error.                            |                | 15      |
 
 ## Returns
@@ -101,4 +102,21 @@ host = "ora_host_01"
 sla = "OracleTest"
 
 snapshot = rubrik.on_demand_snapshot(object_name, object_type, sla_name=sla, hostname=host, force_full=False )
+```
+
+### Share
+
+```py
+import rubrik_cdm
+
+rubrik = rubrik_cdm.Connect()
+
+object_name = "python-sdk-share-demo"
+object_type = "share"
+sla = "Gold"
+fileset = "/etc"
+hostname = "python-sdk-demo"
+share_type = "NFS"
+
+snapshot = rubrik.on_demand_snapshot(object_name, object_type, sla, fileset, hostname=hostname, share_type=share_type)
 ```

--- a/docs/on_demand_snapshot.md
+++ b/docs/on_demand_snapshot.md
@@ -19,9 +19,9 @@ def on_demand_snapshot(object_name, object_type, sla_name='current', fileset=Non
 | sql_host     | str  | The name of the SQL Host hosting the specified database. Only required when taking a on-demand snapshot of a MSSQL DB.                  | None           | None    |
 | sql_instance | str  | The name of the SQL Instance hosting the specified database. Only required when taking a on-demand snapshot of a MSSQL DB.              | None           | None    |
 | sql_db       | str  | TThe name of the SQL DB. Only required when taking a on-demand snapshot of a MSSQL DB.                                                  | None           | None    |
-| hostname     | str  | The host name, or one of the host names in the cluster, that the Oracle database is running or the NAS server hostname. Required when the object_type is oracle_db or share. | None           | None    |
+| hostname     | str  | Required when the `object_type` is either `oracle_db` or `share`. When `oracle_db` is the `object_type`, this argument corresponds to the host name, or one of those host names in the cluster that the Oracle database is running. When `share` is the `object_type` this argument corresponds to the NAS server host name. | None           | None    |
 | force_full   | bool | If True will force a new full image backup of an Oracle database. Used when the object_type is oracle_db                                | True, False    | False   |
-| share_type   | str  | The type of NAS share i.e. NFS or SMB. Only required when taking a snapshot of a Share.                                                 | True, False    | False   |
+| share_type   | str  | The type of NAS share i.e. NFS or SMB. Only required when taking a snapshot of a Share.                                                 | NFS or SMB    | False   |
 | timeout      | int  | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error.                            |                | 15      |
 
 ## Returns
@@ -104,7 +104,7 @@ sla = "OracleTest"
 snapshot = rubrik.on_demand_snapshot(object_name, object_type, sla_name=sla, hostname=host, force_full=False )
 ```
 
-### Share
+### NAS Share
 
 ```py
 import rubrik_cdm

--- a/rubrik_cdm/data_management.py
+++ b/rubrik_cdm/data_management.py
@@ -43,7 +43,7 @@ class Data_Management(_API):
             sla_name {str} -- The SLA Domain name you want to assign the on-demand snapshot to. By default, the currently assigned SLA Domain will be used. (default: {'current'})
             fileset {str} -- The name of the Fileset you wish to backup. Only required when taking a on-demand snapshot of a physical host or share. (default: {'None'})
             host_os {str} -- The operating system for the physical host. Only required when taking a on-demand snapshot of a physical host. (default: {'None'}) (choices: {Linux, Windows})
-            hostname {str} -- The host name, or one of the host names in the cluster, that the Oracle database is running or the NAS server hostname. Required when the object_type is oracle_db or share.
+            hostname {str} -- Required when the object_type is either oracle_db or share. When oracle_db is the object_type, this argument corresponds to the host name, or one of those host names in the cluster that the Oracle database is running. When share is the object_type this argument corresponds to the NAS server host name.
             force_full {bool} -- If True will force a new full image backup of an Oracle database. (default: {False})
             share_type {str} -- The type of NAS share i.e. NFS or SMB. Only required when taking a snapshot of a Share.
             timeout {int} -- The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. (default: {15})

--- a/sample/on_demand_snapshot.py
+++ b/sample/on_demand_snapshot.py
@@ -18,5 +18,13 @@ object_type = "physical_host"
 sla = "Gold"
 fileset = "/etc"
 host_os = "Linux"
-
 snapshot = rubrik.on_demand_snapshot(physical_host_name, object_type, sla, fileset, host_os)
+
+# Share
+object_name = "python-sdk-share-demo"
+object_type = "share"
+sla = "Gold"
+fileset = "/etc"
+hostname = "python-sdk-demo"
+share_type = "NFS"
+snapshot = rubrik.on_demand_snapshot(object_name, object_type, sla, fileset, hostname=hostname, share_type=share_type)

--- a/sample/on_demand_snapshot.py
+++ b/sample/on_demand_snapshot.py
@@ -20,7 +20,7 @@ fileset = "/etc"
 host_os = "Linux"
 snapshot = rubrik.on_demand_snapshot(physical_host_name, object_type, sla, fileset, host_os)
 
-# Share
+# NAS Share
 object_name = "python-sdk-share-demo"
 object_type = "share"
 sla = "Gold"

--- a/tests/unit/data_management_test.py
+++ b/tests/unit/data_management_test.py
@@ -9,7 +9,7 @@ def test_on_demand_snapshot_invalid_object_type(rubrik):
 
     error_message = error.value.args[0]
 
-    assert error_message == "The on_demand_snapshot() `object_type` argument must be one of the following: ['vmware', 'physical_host', 'ahv', 'mssql_db', 'oracle_db']."
+    assert error_message == "The on_demand_snapshot() `object_type` argument must be one of the following: ['vmware', 'physical_host', 'ahv', 'mssql_db', 'oracle_db', 'share']."
 
 
 def test_on_demand_snapshot_invalid_host_os_type(rubrik):


### PR DESCRIPTION
# Description

Added NAS share to on_demand_snapshot

## Related Issue

Related to On Demand Snapshot for NAS Shares https://github.com/rubrikinc/rubrik-sdk-for-python/issues/50

## Motivation and Context

Existing function needs this feature.

## How Has This Been Tested?

Locally on GAIA
```
[2019-10-04 19:07:49,353] [DEBUG] -- on_demand_snapshot: Searching the Rubrik cluster for the NAS Host 'emea1-ntap01.rubrikdemo.com'.
[2019-10-04 19:07:49,354] [DEBUG] -- cluster_version: Getting the software version of the Rubrik cluster.
[2019-10-04 19:07:49,354] [DEBUG] -- GET https://emea1-rbk01.rubrikdemo.com/api/v1/cluster/me/version
[2019-10-04 19:07:52,101] [DEBUG] -- <Response [200]>

[2019-10-04 19:07:52,101] [DEBUG] -- object_id: Getting the object id for the physical_host object 'emea1-ntap01.rubrikdemo.com'.
[2019-10-04 19:07:52,102] [DEBUG] -- GET https://emea1-rbk01.rubrikdemo.com/api/v1/host?primary_cluster_id=local&name=emea1-ntap01.rubrikdemo.com
[2019-10-04 19:07:54,247] [DEBUG] -- <Response [200]>

[2019-10-04 19:07:54,247] [DEBUG] -- on_demand_snapshot: Searching the Rubrik cluster for the NAS share 'ntap_smb'.
[2019-10-04 19:07:54,247] [DEBUG] -- Searching the Rubrik cluster for the host ID.
[2019-10-04 19:07:54,247] [DEBUG] -- cluster_version: Getting the software version of the Rubrik cluster.
[2019-10-04 19:07:54,248] [DEBUG] -- GET https://emea1-rbk01.rubrikdemo.com/api/v1/cluster/me/version
[2019-10-04 19:07:56,199] [DEBUG] -- <Response [200]>

[2019-10-04 19:07:56,199] [DEBUG] -- object_id: Getting the object id for the physical_host object 'emea1-ntap01.rubrikdemo.com'.
[2019-10-04 19:07:56,199] [DEBUG] -- GET https://emea1-rbk01.rubrikdemo.com/api/v1/host?primary_cluster_id=local&name=emea1-ntap01.rubrikdemo.com
[2019-10-04 19:07:58,035] [DEBUG] -- <Response [200]>

[2019-10-04 19:07:58,036] [DEBUG] -- object_id: Getting the object id for the share object 'ntap_smb'.
[2019-10-04 19:07:58,036] [DEBUG] -- GET https://emea1-rbk01.rubrikdemo.com/api/internal/host/share?share_type=SMB
[2019-10-04 19:07:59,878] [DEBUG] -- <Response [200]>

[2019-10-04 19:07:59,878] [DEBUG] -- on_demand_snapshot: Searching the Rubrik cluster for the full Fileset.
[2019-10-04 19:07:59,878] [DEBUG] -- GET https://emea1-rbk01.rubrikdemo.com/api/v1/fileset?share_id=HostShare:::11b5ce39-0c8c-48bd-9bb3-f5381e6868cb&host_id=Host:::6931a798-f499-4c29-b8c9-a293b09c4f85&is_relic=false&name=everything
[2019-10-04 19:08:02,449] [DEBUG] -- <Response [200]>

[2019-10-04 19:08:02,449] [DEBUG] -- on_demand_snapshot: Initiating snapshot for the NAS Share 'ntap_smb' Fileset 'everything'.
[2019-10-04 19:08:02,449] [DEBUG] -- POST https://emea1-rbk01.rubrikdemo.com/api/v1/fileset/Fileset:::faae6bda-4365-4863-a4b4-3c1d713b473b/snapshot
[2019-10-04 19:08:02,450] [DEBUG] -- Config: {"slaId": "3034bf7c-fea7-4452-860c-2c37aaae071d"}
[2019-10-04 19:08:04,384] [DEBUG] -- Response: {"id":"CREATE_FILESET_SNAPSHOT_faae6bda-4365-4863-a4b4-3c1d713b473b_d29fc52e-8c08-486a-a785-4297875056ae:::0","status":"QUEUED","progress":0.0,"startTime":"2019-10-04T18:08:03.503Z","links":[{"href":"https://emea1-rbk01.rubrikdemo.com/api/v1/fileset/request/CREATE_FILESET_SNAPSHOT_faae6bda-4365-4863-a4b4-3c1d713b473b_d29fc52e-8c08-486a-a785-4297875056ae:::0","rel":"self"}]}
[2019-10-04 19:08:04,384] [DEBUG] -- <Response [202]>

({'id': 'CREATE_FILESET_SNAPSHOT_faae6bda-4365-4863-a4b4-3c1d713b473b_d29fc52e-8c08-486a-a785-4297875056ae:::0', 'status': 'QUEUED', 'progress': 0.0, 'startTime': '2019-10-04T18:08:03.503Z', 'links': [{'href': 'https://emea1-rbk01.rubrikdemo.com/api/v1/fileset/request/CREATE_FILESET_SNAPSHOT_faae6bda-4365-4863-a4b4-3c1d713b473b_d29fc52e-8c08-486a-a785-4297875056ae:::0', 'rel': 'self'}]}, 'https://emea1-rbk01.rubrikdemo.com/api/v1/fileset/request/CREATE_FILESET_SNAPSHOT_faae6bda-4365-4863-a4b4-3c1d713b473b_d29fc52e-8c08-486a-a785-4297875056ae:::0')
```

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/rubrik-sdk-for-python/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
