### PR TITLE
added get_sql_db

### DIFF
--- a/docs/get_sql_db.md
+++ b/docs/get_sql_db.md
@@ -1,8 +1,8 @@
 # get_sql_db
 
-""" Retrieves summary information for Microsoft SQL databases. Each keyword argument is a query parameter to filter the database details returned i.e. you can query for a specific database name, hostname, instance, is_relic, effective_sla_domain etc.
+Retrieves summary information for SQL databases. Each keyword argument is a query parameter to filter the database details returned i.e. you can query for a specific database name, hostname, instance, is_relic, effective_sla_domain etc.
 ```py
-def get_sql_db(instance_id=None, availability_group_id=None, effective_sla_domain_id=None, primary_cluster_id=None, name=None, instance=None, hostname=None, sla_assignment=None, limit=None, offset=None,  is_relic=None, is_live_mount=None, is_log_shipping_secondary=None, sort_by=None, sort_order=None, timeout=15)
+def get_sql_db(self, name=None, instance=None, hostname=None, availability_group=None, effective_sla_domain=None, primary_cluster_id='local', sla_assignment=None, limit=None, offset=None,  is_relic=None, is_live_mount=None, is_log_shipping_secondary=None, sort_by=None, sort_order=None, timeout=15)
 ```
 
 ## Keyword Arguments
@@ -11,10 +11,9 @@ def get_sql_db(instance_id=None, availability_group_id=None, effective_sla_domai
 | name                      | str  | Filter by a substring of the database name.                                 |         |         |
 | instance                  | str  | The SQL instance name of the database.                                      |         |         |
 | hostname                  | str  | The SQL host name of the database.                                          |         |         |
-| instance_id               | str  | Filter by Microsoft SQL instance.                                           |         |         |
-| availability_group_id     | str  | Filter by the id of an Always On Availability Group.                        |         |         |
-| effective_sla_domain_id   | str  | Filter by ID of effective SLA Domain.                                       |         |         |
-| primary_cluster_id        | str  | Filter by primary cluster ID, or local.                                     |         |         |
+| availability_group        | str  | Filter by the name of the Always On Availability Group.                     |         |         |
+| effective_sla_domain      | str  | Filter by the name of the effective SLA Domain.                             |         |         |
+| primary_cluster_id        | str  | Filter by primary cluster ID, or local.                                     |         |  local  |
 | sla_assignment            | str  | Filter by SLA Domain assignment type.                                       |Direct, Derived, Unassigned |         |
 | limit                     | int  | Limit the number of matches returned.                                       |         |         |
 | offset                    | int  | Ignore these many matches in the beginning.                                 |         |         |

--- a/docs/get_sql_db.md
+++ b/docs/get_sql_db.md
@@ -1,0 +1,43 @@
+# get_sql_db
+
+""" Retrieves summary information for Microsoft SQL databases. Each keyword argument is a query parameter to filter the database details returned i.e. you can query for a specific database name, hostname, instance, is_relic, effective_sla_domain etc.
+```py
+def get_sql_db(instance_id=None, availability_group_id=None, effective_sla_domain_id=None, primary_cluster_id=None, name=None, instance=None, hostname=None, sla_assignment=None, limit=None, offset=None,  is_relic=None, is_live_mount=None, is_log_shipping_secondary=None, sort_by=None, sort_order=None, timeout=15)
+```
+
+## Keyword Arguments
+| Name                      | Type | Description                                                                 | Choices | Default |
+|---------------------------|------|-----------------------------------------------------------------------------|---------|---------|
+| name                      | str  | Filter by a substring of the database name.                                 |         |         |
+| instance                  | str  | The SQL instance name of the database.                                      |         |         |
+| hostname                  | str  | The SQL host name of the database.                                          |         |         |
+| instance_id               | str  | Filter by Microsoft SQL instance.                                           |         |         |
+| availability_group_id     | str  | Filter by the id of an Always On Availability Group.                        |         |         |
+| effective_sla_domain_id   | str  | Filter by ID of effective SLA Domain.                                       |         |         |
+| primary_cluster_id        | str  | Filter by primary cluster ID, or local.                                     |         |         |
+| sla_assignment            | str  | Filter by SLA Domain assignment type.                                       |Direct, Derived, Unassigned |         |
+| limit                     | int  | Limit the number of matches returned.                                       |         |         |
+| offset                    | int  | Ignore these many matches in the beginning.                                 |         |         |
+| is_relic                  | bool | Filter by the isRelic field of the database.                                |         |         |
+| is_live_mount             | bool | Filter database summary information by the value of the isLiveMount field.  |         |         |
+| is_log_shipping_secondary | bool | Filter database summary information by the value of the isLogShippingSecondary field.|         |         |
+| sort_by                   | str  | Sort results based on the specified attribute.                              | effectiveSlaDomainName, name |         |
+| sort_order                | str  | Sort order, either ascending or descending.                                 | asc, desc |         |
+| timeout                   | int  | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. |         |    15     |
+
+## Returns
+| Type | Return Value                                                                                  |
+|------|-----------------------------------------------------------------------------------------------|
+| dict | The full response of `GET /v1/mssql/db?{query}`.                                              |
+## Example
+```py
+import rubrik_cdm
+
+rubrik = rubrik_cdm.Connect()
+
+name = "python-sdk-demo"
+instance = 'MSSQLSERVER'
+hostname = 'sql.rubrikdemo.com'
+
+get_db = rubrik.get_sql_db(name=name, instance=instance, hostname=hostname)
+```

--- a/docs/get_sql_db.md
+++ b/docs/get_sql_db.md
@@ -37,6 +37,10 @@ rubrik = rubrik_cdm.Connect()
 name = "python-sdk-demo"
 instance = 'MSSQLSERVER'
 hostname = 'sql.rubrikdemo.com'
+availability_group = 'sql.rubrikdemo.com'
+effective_sla_domain = 'Gold'
+primary_cluster_id = 'local'
+sla_assignment = 'Direct'
 
-get_db = rubrik.get_sql_db(name=name, instance=instance, hostname=hostname)
+get_db = rubrik.get_sql_db(name=name, instance=instance, hostname=hostname, availability_group=availability_group, effective_sla_domain=effective_sla_domain, primary_cluster_id=primary_cluster_id, sla_assignment=sla_assignment)
 ```

--- a/docs/get_vsphere_vm.md
+++ b/docs/get_vsphere_vm.md
@@ -2,7 +2,7 @@
 
 Get summary of all the VMs. Each keyword argument is a query parameter to filter the VM details returned i.e. you can query for a specific VM name, is_relic, effective_sla_domain etc.
 ```py
-def get_vsphere_vm(self, name=None, is_relic=None, effective_sla_domain_id=None, primary_cluster_id=None, limit=None, offset=None, moid=None, sla_assignment=None, guest_os_name=None, sort_by=None, sort_order=None, timeout=15):
+def get_vsphere_vm(name=None, is_relic=None, effective_sla_domain_id=None, primary_cluster_id=None, limit=None, offset=None, moid=None, sla_assignment=None, guest_os_name=None, sort_by=None, sort_order=None, timeout=15)
 ```
 
 ## Keyword Arguments

--- a/docs/get_vsphere_vm_details.md
+++ b/docs/get_vsphere_vm_details.md
@@ -2,7 +2,7 @@
 
 Retrieve details for a virtual machine.
 ```py
-def get_vsphere_vm_details(self, vm_name, timeout=15):
+def get_vsphere_vm_details(self, vm_name, timeout=15)
 ```
 
 ## Arguments

--- a/docs/get_vsphere_vm_file.md
+++ b/docs/get_vsphere_vm_file.md
@@ -2,7 +2,7 @@
 
 Search for a file in the snapshots of a virtual machine. Specify the file by full path prefix or filename prefix.
 ```py
-def get_vsphere_vm_file(self, vm_name, path, timeout=15):
+def get_vsphere_vm_file(self, vm_name, path, timeout=15)
 ```
 
 ## Arguments

--- a/docs/get_vsphere_vm_snapshot.md
+++ b/docs/get_vsphere_vm_snapshot.md
@@ -2,7 +2,7 @@
 
 Retrieve summary information for the snapshots of a virtual machine.
 ```py
-def get_vsphere_vm_snapshot(self, vm_name, timeout=15):
+def get_vsphere_vm_snapshot(self, vm_name, timeout=15)
 ```
 
 ## Arguments

--- a/rubrik_cdm/data_management.py
+++ b/rubrik_cdm/data_management.py
@@ -884,7 +884,7 @@ class Data_Management(_API):
 
         # Validate the Date formating
         try:
-            snapshot_date = datetime.strptime(date, '%m-%d-%Y')
+            datetime.strptime(date, '%m-%d-%Y')
         except ValueError:
             raise InvalidParameterException(
                 "The date argument '{}' must be formatd as 'Month-Date-Year' (ex: 8-9-2018).".format(date))
@@ -1771,15 +1771,14 @@ class Data_Management(_API):
         self.log("get_vsphere_vm_file: Search for file/path {} in the snapshots of a virtual machine {}".format(path, vm_id))
         return self.get('v1', '/vmware/vm/{}/search?path={}'.format(vm_id, path), timeout)
 
-    def get_sql_db(self, name=None, instance=None, hostname=None, instance_id=None, availability_group_id=None, effective_sla_domain_id=None, primary_cluster_id=None, sla_assignment=None, limit=None, offset=None,  is_relic=None, is_live_mount=None, is_log_shipping_secondary=None, sort_by=None, sort_order=None, timeout=15):  # pylint: ignore
-        """ Retrieves summary information for Microsoft SQL databases. Each keyword argument is a query parameter to filter the database details returned i.e. you can query for a specific database name, hostname, instance, is_relic, effective_sla_domain etc.
+    def get_sql_db(self, name=None, instance=None, hostname=None, availability_group=None, effective_sla_domain=None, primary_cluster_id='local', sla_assignment=None, limit=None, offset=None,  is_relic=None, is_live_mount=None, is_log_shipping_secondary=None, sort_by=None, sort_order=None, timeout=15):  # pylint: ignore
+        """Retrieves summary information for SQL databases. Each keyword argument is a query parameter to filter the database details returned i.e. you can query for a specific database name, hostname, instance, is_relic, effective_sla_domain etc.
         Keyword Arguments:
             name {str} -- Filter by a substring of the database name.
             instance {str} -- The SQL instance name of the database.
             hostname {str} -- The SQL host name of the database.
-            instance_id {str} -- Filter by Microsoft SQL instance.
-            availability_group_id {str} -- Filter by the id of an Always On Availability Group.
-            effective_sla_domain_id {str} -- Filter by ID of effective SLA Domain.
+            availability_group {str} -- Filter by the name of the Always On Availability Group.
+            effective_sla_domain {str} -- Filter by the name of the effective SLA Domain.
             primary_cluster_id {str} -- Filter by primary cluster ID, or local.
             sla_assignment {str} -- Filter by SLA Domain assignment type. (Direct, Derived, Unassigned)
             limit {int} -- Limit the number of matches returned.
@@ -1793,9 +1792,23 @@ class Data_Management(_API):
         Returns:
             dict -- The full response of `GET /v1/mssql/db?{query}`
         """
+        if availability_group is not None:
+            self.log("get_sql_db: Searching the Rubrik cluster for the ID of the availability_group {}.".format(availability_group))
+            ag_summary = self.get(
+                'internal', '/mssql/availability_group', timeout=timeout)
+            for ag in ag_summary['data']:
+                if availability_group == ag['name']:
+                    availability_group_id = ag['id']
+        else:
+            availability_group_id = None
         
-        parameters = {'instance_id':instance_id,
-                      'availability_group_id':availability_group_id,
+        if effective_sla_domain is not None:
+            self.log("get_sql_db: Searching the Rubrik cluster for the ID of the SLA Domain '{}'.".format(effective_sla_domain))
+            effective_sla_domain_id = self.object_id(effective_sla_domain, 'sla', timeout=timeout)
+        else:
+            effective_sla_domain_id = None
+
+        parameters = {'availability_group_id':availability_group_id,
                       'effective_sla_domain_id':effective_sla_domain_id,
                       'primary_cluster_id':primary_cluster_id,
                       'name':name,
@@ -1842,13 +1855,13 @@ class Data_Management(_API):
         
         result = []
 
-        if instance == None and hostname == None:
+        if instance is None and hostname is None:
             return databases['data']
-        elif instance == None and hostname != None:
+        elif instance is None and hostname is not None:
             for item in databases['data']:
                 if item['rootProperties']['rootName'] == hostname:
                     result.append(item)
-        elif instance != None and hostname == None:
+        elif instance is not None and hostname is None:
             try:
                 for item in databases['data']:
                     for replica in item['replicas']:
@@ -1859,7 +1872,7 @@ class Data_Management(_API):
                 pass
             else:
                 result = [item for item in databases['data'] if replica['instanceName'] == instance]
-        elif instance != None and hostname != None:
+        elif instance is not None and hostname is not None:
             try:
                 for item in databases['data']:
                     for replica in item['replicas']:

--- a/sample/get_sql_db.py
+++ b/sample/get_sql_db.py
@@ -5,5 +5,9 @@ rubrik = rubrik_cdm.Connect()
 name = "python-sdk-demo"
 instance = 'MSSQLSERVER'
 hostname = 'sql.rubrikdemo.com'
+availability_group = 'sql.rubrikdemo.com'
+effective_sla_domain = 'Gold'
+primary_cluster_id = 'local'
+sla_assignment = 'Direct'
 
-get_db = rubrik.get_sql_db(name=name, instance=instance, hostname=hostname)
+get_db = rubrik.get_sql_db(name=name, instance=instance, hostname=hostname, availability_group=availability_group, effective_sla_domain=effective_sla_domain, primary_cluster_id=primary_cluster_id, sla_assignment=sla_assignment)

--- a/sample/get_sql_db.py
+++ b/sample/get_sql_db.py
@@ -1,0 +1,9 @@
+import rubrik_cdm
+
+rubrik = rubrik_cdm.Connect()
+
+name = "python-sdk-demo"
+instance = 'MSSQLSERVER'
+hostname = 'sql.rubrikdemo.com'
+
+get_db = rubrik.get_sql_db(name=name, instance=instance, hostname=hostname)


### PR DESCRIPTION
# Description

Retrieves summary information for Microsoft SQL databases. Each keyword argument is a query parameter to filter the database details returned i.e. you can query for a specific database name, hostname, instance, is_relic, effective_sla_domain etc.

## Related Issue
https://github.com/rubrikinc/rubrik-sdk-for-python/issues/161

## Motivation and Context

Why is this change required? What problem does it solve?

## How Has This Been Tested?

Tested locally on laptop and GAIA

## Screenshots (if appropriate):
```
[2019-10-15 16:03:04,062] [DEBUG] -- get_sql_db: checking the provided query parameters.
[2019-10-15 16:03:04,062] [DEBUG] -- get_sql_db: Get summary of all the databases returned by the query.
[2019-10-15 16:03:04,062] [DEBUG] -- GET https://emea1-rbk01.rubrikdemo.com/api/v1/mssql/db?name=AdventureWorks2016_EXT&
[2019-10-15 16:03:07,716] [DEBUG] -- <Response [200]>

[{'hasPermissions': True, 'effectiveSlaDomainId': '4ba2a68c-1308-491c-a1d1-2db714af4dfb', 
'primaryClusterId': '297cd5fc-253c-40c5-ad1c-60b090fb2a19', 'instanceName': 'MSSQLSERVER',
 'unprotectableReasons': [], 'effectiveSlaSourceObjectId': 'MssqlInstance:::cddef5cc-5181-4d29-
ab50-c86b0163a27d', 'effectiveSlaSourceObjectName': 'MSSQLSERVER', 'isOnline': True,
 'configuredSlaDomainId': 'INHERIT', 'isLogShippingSecondary': False, 'effectiveSlaDomainName': 
'4hr-30d-Azure', 'instanceId': 'MssqlInstance:::cddef5cc-5181-4d29-ab50-c86b0163a27d', 
'copyOnly': False, 'recoveryModel': 'FULL', 'id': 'MssqlDatabase:::b498a8f5-0c4c-4e47-b309-
865e6c66066f', 'state': 'ONLINE', 'isInAvailabilityGroup': False, 'isLiveMount': False, 
'configuredSlaDomainName': 'Inherit', 'replicas': [{'instanceId': 'MssqlInstance:::cddef5cc-5181-
4d29-ab50-c86b0163a27d', 'instanceName': 'MSSQLSERVER', 'recoveryModel': 'FULL', 'state': 
'ONLINE', 'hasPermissions': True, 'isStandby': False, 'recoveryForkGuid': 'DCD6D029-2C9A-4B42-
AAFD-8B3010A680BC', 'isArchived': False, 'isDeleted': False, 'rootProperties': {'rootType': 'Host', 
'rootId': 'Host:::bcb1bf54-aca5-47ef-996c-581d94c02a86', 'rootName': 'em1-promowol-
w1.rubrikdemo.com'}}], 'slaAssignment': 'Derived', 'rootProperties': {'rootType': 'Host', 'rootId': 
'Host:::bcb1bf54-aca5-47ef-996c-581d94c02a86', 'rootName': 'em1-promowol-
w1.rubrikdemo.com'}, 'logBackupRetentionHours': 168, 'isRelic': False, 'name': 
'AdventureWorks2016_EXT', 'logBackupFrequencyInSeconds': 3600}]
```
## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/rubrik-sdk-for-python/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
