### PR TITLE
Added 'UnixLike' as OS type for assigning filesets to a host.

### DIFF
--- a/docs/assign_physical_host_fileset.md
+++ b/docs/assign_physical_host_fileset.md
@@ -1,6 +1,6 @@
 # assign_physical_host_fileset
 
-Assign a Fileset to a Linux or Windows machine. If you have multiple Filesets with identical names, you will need to populate the Filesets properties (i.e this functions keyword arguments) to find a specific match. Filesets with identical names and properties are not supported.
+Assign a Fileset to a Linux, Unix or Windows machine. If you have multiple Filesets with identical names, you will need to populate the Filesets properties (i.e this functions keyword arguments) to find a specific match. Filesets with identical names and properties are not supported.
 ```py
 def assign_physical_host_fileset(hostname, fileset_name, operating_system, sla_name, include=None, exclude=None, exclude_exception=None, follow_network_shares=False, backup_hidden_folders=False, timeout=30)
 ```
@@ -9,8 +9,8 @@ def assign_physical_host_fileset(hostname, fileset_name, operating_system, sla_n
 | Name        | Type | Description                                                                 | Choices |
 |-------------|------|-----------------------------------------------------------------------------|---------|
 | hostname  | str  | The hostname or IP Address of the physical host you wish to associate to the Fileset. |         |
-| fileset_name  | str  | The name of the Fileset you wish to assign to the Linux or Windows host. |         |
-| operating_system  | str  | The operating system of the physical host you are assigning a Fileset to.  |    Linux, Windows     |
+| fileset_name  | str  | The name of the Fileset you wish to assign to the Linux, Unix or Windows host. |         |
+| operating_system  | str  | The operating system of the physical host you are assigning a Fileset to.  |    Linux, Windows,UnixLike     |
 | sla_name  | str  | The name of the SLA Domain to associate with the Fileset. |         |
 ## Keyword Arguments
 | Name        | Type | Description                                                                 | Choices | Default |

--- a/rubrik_cdm/physical.py
+++ b/rubrik_cdm/physical.py
@@ -322,13 +322,13 @@ class Physical(Api):
             return self.post('internal', '/host/share', config, timeout)
 
     def assign_physical_host_fileset(self, hostname, fileset_name, operating_system, sla_name, include=None, exclude=None, exclude_exception=None, follow_network_shares=False, backup_hidden_folders=False, timeout=30):  # pylint: ignore
-        """Assign a Fileset to a Linux or Windows machine. If you have multiple Filesets with identical names, you will need to populate the Filesets properties (i.e this functions keyword arguments)
+        """Assign a Fileset to a Linux, Unix or Windows machine. If you have multiple Filesets with identical names, you will need to populate the Filesets properties (i.e this functions keyword arguments)
         to find a specific match. Filesets with identical names and properties are not supported.
 
         Arguments:
             hostname {str} -- The hostname or IP Address of the physical host you wish to associate to the Fileset.
-            fileset_name {str} -- The name of the Fileset you wish to assign to the Linux or Windows host.
-            operating_system {str} -- The operating system of the physical host you are assigning a Fileset to. (choices: {Linux, Windows})
+            fileset_name {str} -- The name of the Fileset you wish to assign to the Linux, Unix or Windows host.
+            operating_system {str} -- The operating system of the physical host you are assigning a Fileset to. (choices: {Linux, Windows, UnixLike})
             sla_name {str} -- The name of the SLA Domain to associate with the Fileset.
 
         Keyword Arguments:
@@ -347,7 +347,7 @@ class Physical(Api):
 
         self.function_name = inspect.currentframe().f_code.co_name
 
-        valid_operating_system = ['Linux', 'Windows']
+        valid_operating_system = ['Linux', 'Windows', 'UnixLike']
 
         if operating_system not in valid_operating_system:
             raise InvalidParameterException("The assign_physical_host_fileset() operating_system argument must be one of the following: {}.".format(

--- a/tests/unit/physical_test.py
+++ b/tests/unit/physical_test.py
@@ -381,7 +381,7 @@ def test_create_physical_fileset_invalid_operating_system(rubrik):
 
     error_message = error.value.args[0]
 
-    assert error_message == "The create_physical_fileset() operating_system argument must be one of the following: ['Linux', 'Windows', 'UnixLike']."
+    assert error_message == "The create_physical_fileset() operating_system argument must be one of the following: ['Linux', 'Windows']."
 
 
 def test_create_physical_fileset_invalid_follow_network_shares(rubrik):

--- a/tests/unit/physical_test.py
+++ b/tests/unit/physical_test.py
@@ -381,7 +381,7 @@ def test_create_physical_fileset_invalid_operating_system(rubrik):
 
     error_message = error.value.args[0]
 
-    assert error_message == "The create_physical_fileset() operating_system argument must be one of the following: ['Linux', 'Windows']."
+    assert error_message == "The create_physical_fileset() operating_system argument must be one of the following: ['Linux', 'Windows', 'UnixLike']."
 
 
 def test_create_physical_fileset_invalid_follow_network_shares(rubrik):
@@ -762,7 +762,7 @@ def test_assign_physical_host_fileset_invalid_operating_system(rubrik):
 
     error_message = error.value.args[0]
 
-    assert error_message == "The assign_physical_host_fileset() operating_system argument must be one of the following: ['Linux', 'Windows']."
+    assert error_message == "The assign_physical_host_fileset() operating_system argument must be one of the following: ['Linux', 'Windows', 'UnixLike']."
 
 
 def test_assign_physical_host_fileset_invalid_follow_network_shares(rubrik):


### PR DESCRIPTION
# Description

Added 'UnixLike' as OS type for assigning filesets to a host.

## Motivation and Context

At the moment, you cannot assign a fileset to a Unix host (AIX, for example).

## How Has This Been Tested?

In my own lab by assigning a fileset to an AIX host and also testing the v1 /host API with the OS type 'UnixLike'.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/rubrik-sdk-for-python/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
