### PR TITLE
Login banner

### DIFF
--- a/docs/configure_login_banner.md
+++ b/docs/configure_login_banner.md
@@ -1,4 +1,4 @@
-# configure_syslog
+# configure_login_banner
 
 Configure the Login Banner Text on the Rubrik cluster.
 ```py

--- a/docs/configure_login_banner.md
+++ b/docs/configure_login_banner.md
@@ -1,0 +1,30 @@
+# configure_syslog
+
+Configure the Login Banner Text on the Rubrik cluster.
+```py
+def configure_login_banner(banner, timeout=15)
+```
+
+## Arguments
+| Name        | Type | Description                                                                 | Choices |
+|-------------|------|-----------------------------------------------------------------------------|---------|
+| banner  | str  | The Login Banner Text you wish to see when the Rubrik cluster login page loads. |         |
+## Keyword Arguments
+| Name        | Type | Description                                                                 | Choices | Default |
+|-------------|------|-----------------------------------------------------------------------------|---------|---------|
+| timeout  | int  | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error.  |         |    15     |
+
+## Returns
+| Type | Return Value                                                                                   |
+|------|-----------------------------------------------------------------------------------------------|
+| str  | No change required. The Rubrik cluster is already configured with the login banner text `banner`. |
+| dict  | The full API response for `PUT /internal/cluster/me/login_banner'` |
+## Example
+```py
+import rubrik_cdm
+
+rubrik = rubrik_cdm.Connect()
+
+bannerText = "Welcome to Rubrik"
+configure_banner = rubrik.configure_login_banner(bannerText)
+```

--- a/rubrik_cdm/cluster.py
+++ b/rubrik_cdm/cluster.py
@@ -589,6 +589,34 @@ class Cluster(Api):
 
         return self.post("internal", "/cluster/me/dns_nameserver", server_ip, timeout)
 
+    def configure_login_banner(self, banner, timeout=15):
+        """Configure the Login Banner Text on the Rubrik cluster.
+
+        Arguments:
+            banner {str} -- The Login Banner Text you wish to see when the Rubrik cluster login page loads.
+
+        Keyword Arguments:
+            timeout {int} -- The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. (default: {15})
+
+        Returns:
+            str -- No change required. The Rubrik cluster is already configured with the login banner text '`banner`'.
+            dict -- The full API response for `PUT /internal/cluster/me/login_banner'`
+        """
+
+        self.function_name = inspect.currentframe().f_code.co_name
+
+        self.log("configure_login_banner: Retrieving the current login banner of the Rubrik cluster.")
+        current_login_banner = self.get("internal", "/cluster/me/login_banner", timeout=timeout)
+        
+        config = {}
+        config["loginBanner"] = banner
+
+        if config == current_login_banner:
+            return "No change required. The Rubrik cluster is already configured with the login banner text '`banner`'."
+
+        self.log("configure_login_banner: Setting the login banner of the Rubrik cluster.")
+        return self.put("internal", "/cluster/me/login_banner", config, timeout)
+
     def configure_search_domain(self, search_domain, timeout=15):
         """Configure the DNS search domains on the Rubrik cluster.
 

--- a/sample/configure_login_banner.py
+++ b/sample/configure_login_banner.py
@@ -3,4 +3,4 @@ import rubrik_cdm
 rubrik = rubrik_cdm.Connect()
 
 bannerText = "Welcome To Rubrik"
-configure_ntp = rubrik.configure_login_banner(bannerText)
+configure_banner = rubrik.configure_login_banner(bannerText)

--- a/sample/configure_login_banner.py
+++ b/sample/configure_login_banner.py
@@ -1,0 +1,6 @@
+import rubrik_cdm
+
+rubrik = rubrik_cdm.Connect()
+
+bannerText = "Testing Banner Configuration"
+configure_ntp = rubrik.configure_login_banner(bannerText)

--- a/sample/configure_login_banner.py
+++ b/sample/configure_login_banner.py
@@ -2,5 +2,5 @@ import rubrik_cdm
 
 rubrik = rubrik_cdm.Connect()
 
-bannerText = "Testing Banner Configuration"
+bannerText = "Welcome To Rubrik"
 configure_ntp = rubrik.configure_login_banner(bannerText)

--- a/tests/unit/cluster_test.py
+++ b/tests/unit/cluster_test.py
@@ -514,6 +514,23 @@ def test_configure_syslog_invalid_idempotence(rubrik, mocker):
     assert rubrik.configure_syslog("syslog_ip", "TCP") == \
         "No change required. The Rubrik cluster is already configured to use the syslog server 'syslog_ip' on port '514' using the 'TCP' protocol."
 
+def test_configure_login_banner(rubrik, mocker):
+
+    def mock_get_internal_login_banner():
+        return {
+            "loginBanner" : "old_banner"
+        }
+    def mock_put_internal_login_banner():
+        return {
+            "loginBanner" : "new_banner"
+        }
+    mock_get = mocker.patch('rubrik_cdm.Connect.get', autospec=True, spec_set=True)
+    mock_get.return_value = mock_get_internal_login_banner()
+
+    mock_put = mocker.patch('rubrik_cdm.Connect.post', autospec=True, spec_set=True)
+    mock_put.return_value = mock_put_internal_login_banner()
+
+    assert rubrik.configure_login_banner("new_banner") == mock_put_internal_login_banner()
 
 def test_configure_syslog(rubrik, mocker):
 

--- a/tests/unit/cluster_test.py
+++ b/tests/unit/cluster_test.py
@@ -527,7 +527,7 @@ def test_configure_login_banner(rubrik, mocker):
     mock_get = mocker.patch('rubrik_cdm.Connect.get', autospec=True, spec_set=True)
     mock_get.return_value = mock_get_internal_login_banner()
 
-    mock_put = mocker.patch('rubrik_cdm.Connect.post', autospec=True, spec_set=True)
+    mock_put = mocker.patch('rubrik_cdm.Connect.put', autospec=True, spec_set=True)
     mock_put.return_value = mock_put_internal_login_banner()
 
     assert rubrik.configure_login_banner("new_banner") == mock_put_internal_login_banner()


### PR DESCRIPTION
# Description

_Please describe your pull request in detail._

Create a function to configure the Rubrik cluster login banner.

## Related Issue

This project only accepts pull requests related to open issues.

* If suggesting a new feature or change, please discuss it in an issue first.
* If fixing a bug, there should be an issue describing it with steps to reproduce

_Please link to the issue here_
#178 
## Motivation and Context

_Why is this change required? What problem does it solve?_

The login banner can be used to display legal information about the system, location information about the physical location prior to login, and other useful pre-login information.

## How Has This Been Tested?

* Please describe in detail how you tested your changes.
* Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.

Ran `tox` to ensure all tests pass. Tested in python 3.7.4 against Rubrik Edge Node v5.0.2-p1-2130 

## Screenshots (if appropriate):
<img width="1361" alt="image" src="https://user-images.githubusercontent.com/29983598/71627963-35d12880-2bbb-11ea-9693-1377805ab476.png">

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/rubrik-sdk-for-python/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
