### PR TITLE
Add Oracle DB and Oracle Host Support to assign_sla()

### DIFF
--- a/docs/assign_sla.md
+++ b/docs/assign_sla.md
@@ -24,7 +24,7 @@ def assign_sla(self, object_name, sla_name, object_type, log_backup_frequency_in
 | windows_host                    | str  | The name of the Windows host that contains the relevant volume group. Required when the `object_type` is `volume_group`. |         | None    |
 | nas_host                        | str  | The name of the NAS host that contains the relevant share. Required when the `object_type` is `fileset`.                 |         | None    |
 | share                           | str  | The name of the network share a fileset will be created for. Required when the `object_type` is `fileset`.               |         | None    |
-| log_backup_frequency_in_minutes | int  | The Oracle Log Backup frequency you'd like to specify with the SLA. Required when the `object_type` is `oracle_db` or `oracle_host`. | None    |
+| log_backup_frequency_in_minutes | int  | The Oracle Log Backup frequency you'd like to specify with the SLA. Required when the `object_type` is `oracle_db` or `oracle_host`. |         | None    |
 | num_channels                    | int  | Number of RMAN channels used to backup the Oracle database. Required when the `object_type` is `oracle_host`.            |         | 4       |
 | hostname                        | str  | The hostname, or one of the hostnames in a RAC cluster, or the RAC cluster name. Required when the object_type is `oracle_db.` |         | None    |
 | timeout                         | str  | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error.             |         | 30      |

--- a/docs/object_id.md
+++ b/docs/object_id.md
@@ -9,7 +9,7 @@ def object_id(object_name, object_type, host_os=None, timeout=15)
 | Name        | Type | Description                                                                 | Choices |
 |-------------|------|-----------------------------------------------------------------------------|---------|
 | object_name  | str  | The name of the Rubrik object whose ID you wish to lookup. |         |
-| object_type  | str  | The object type you wish to look up.  |    vmware, sla, vmware_host, physical_host, fileset_template, managed_volume, aws_native, vcenter, oracle_db     |
+| object_type  | str  | The object type you wish to look up.  |    vmware, sla, vmware_host, physical_host, fileset_template, managed_volume, aws_native, vcenter, oracle_db, oracle_host     |
 | hostname  | str  | The hostname, or one of the hostnames in a RAC cluster, or the RAC cluster name Required when the object_type is oracle_db.  |      |
 | timeout  | int  | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. (default: {15}) |         |
 
@@ -17,7 +17,10 @@ def object_id(object_name, object_type, host_os=None, timeout=15)
 | Type | Return Value                                                                                   |
 |------|-----------------------------------------------------------------------------------------------|
 | str  | The ID of the provided Rubrik object. |
-## Example
+
+## Examples
+
+### VMware
 ```py
 import rubrik_cdm
 
@@ -27,4 +30,17 @@ vm_name = "python-sdk-demo"
 object_type = "vmware"
 
 vmware_id = rubrik.object_id(vm_name, object_type)
+```
+
+### Oracle Database
+```py
+import rubrik_cdm
+
+rubrik = rubrik_cdm.Connect()
+
+object_name = 'python-sdk-demo'
+object_type = 'oracle_db'
+hostname = 'python-sdk.demo.com'
+
+oracle_id = rubrik.object_id(object_name, object_type)
 ```

--- a/rubrik_cdm/data_management.py
+++ b/rubrik_cdm/data_management.py
@@ -628,7 +628,6 @@ class Data_Management(Api):
 
             host_id = ''
             mssql_id = ''
-            db_sla_lst = []
 
             self.log('Searching the Rubrik cluster for the current hosts.')
             current_hosts = self.get(
@@ -681,17 +680,15 @@ class Data_Management(Api):
                         config['configuredSlaDomainId'] = sla_id
 
                         patch_resp = self.patch("v1", "/mssql/instance/{}".format(mssql_id), config, timeout)
-                        db_sla_lst.append(patch_resp)
             else:
                 raise InvalidParameterException(
                     "Host ID not found for instance '{}'").format(object_name)
 
-            return db_sla_lst
+            return patch_resp
 
         elif object_type == 'oracle_db':
 
             oracle_db_id = ''
-            db_sla_lst = []
 
             self.log('Searching the Rubrik cluster for the current Oracle databases.')
             oracle_db_id = self.object_id(object_name, object_type, hostname=hostname)
@@ -727,12 +724,11 @@ class Data_Management(Api):
                     config['configuredSlaDomainId'] = sla_id
 
                     patch_resp = self.patch("internal", "/oracle/db/{}".format(oracle_db_id), config, timeout)
-                    db_sla_lst.append(patch_resp)
             else:
                 raise InvalidParameterException(
                     "Database ID not found for instance '{}'").format(object_name)
             
-            return db_sla_lst
+            return patch_resp
 
         elif object_type == 'oracle_host':
 

--- a/rubrik_cdm/data_management.py
+++ b/rubrik_cdm/data_management.py
@@ -273,7 +273,7 @@ class Data_Management(Api):
         """Get the ID of a Rubrik object by providing its name.
         Arguments:
             object_name {str} -- The name of the Rubrik object whose ID you wish to lookup.
-            object_type {str} -- The object type you wish to look up. (choices: {vmware, sla, vmware_host, physical_host, fileset_template, managed_volume, mysql_db, mysql_instance, vcenter, ahv, aws_native, oracle_db, volume_group, archival_location, share})
+            object_type {str} -- The object type you wish to look up. (choices: {vmware, sla, vmware_host, physical_host, fileset_template, managed_volume, mysql_db, mysql_instance, vcenter, ahv, aws_native, oracle_db, oracle_host, volume_group, archival_location, share})
         Keyword Arguments:
             host_os {str} -- The operating system for the host. (default: {'None'})
             hostname {str} -- The hostname, for Oracle one of the hostnames in the cluster, that the Oracle database is running. Required when the object_type is oracle_db or share.
@@ -299,6 +299,7 @@ class Data_Management(Api):
             'ahv',
             'aws_native',
             'oracle_db',
+            'oracle_host',
             'volume_group',
             'archival_location',
             'share']
@@ -375,6 +376,10 @@ class Data_Management(Api):
                 "api_version": "internal",
                 "api_endpoint": "/oracle/db?name={}".format(object_name)
             },
+            "oracle_host": {
+                "api_version": "internal",
+                "api_endpoint": "/oracle/hierarchy/root/children?name={}".format(object_name)
+            },            
             "volume_group": {
                 "api_version": "internal",
                 "api_endpoint": "/volume_group?is_relic=false"
@@ -456,31 +461,38 @@ class Data_Management(Api):
             raise InvalidParameterException(
                 "The {} object '{}' was not found on the Rubrik cluster.".format(object_type, object_name))
 
-    def assign_sla(self, object_name, sla_name, object_type, log_backup_frequency_in_seconds=None, log_retention_hours=None, copy_only=None, windows_host=None, nas_host=None, share=None, timeout=30):  # pytest: ignore
+    def assign_sla(self, object_name, sla_name, object_type, log_backup_frequency_in_seconds=None, log_retention_hours=None, copy_only=None, windows_host=None, nas_host=None, share=None, log_backup_frequency_in_minutes=None, num_channels=4, hostname=None, timeout=30):  # pytest: ignore
         """Assign a Rubrik object to an SLA Domain.
         Arguments:
             object_name {str or list} -- The name of the Rubrik object you wish to assign to an SLA Domain. When the 'object_type' is 'volume_group', the object_name can be a list of volumes.
             sla_name {str} -- The name of the SLA Domain you wish to assign an object to. To exclude the object from all SLA assignments use `do not protect` as the `sla_name`. To assign the selected object to the SLA of the next higher level object use `clear` as the `sla_name`.
-            object_type {str} -- The Rubrik object type you want to assign to the SLA Domain. (choices: {vmware, mssql_host, volume_group})
+            object_type {str} -- The Rubrik object type you want to assign to the SLA Domain. (choices: {ahv, mssql_host, oracle_host, vmware, volume_group})
         Keyword Arguments:
-            log_backup_frequency_in_seconds {str} -- The MSSQL Log Backup frequency you'd like to specify with the SLA. Required when the `object_type` is `mssql_host`. (default {None})
-            log_retention_hours {int} -- The MSSQL Log Retention frequency you'd like to specify with the SLA. Required when the `object_type` is `mssql_host`. (default {None})
-            copy_only {int} -- Take Copy Only Backups with MSSQL. Required when the `object_type` is `mssql_host`. (default {None})
+            log_backup_frequency_in_seconds {int} -- The MSSQL Log Backup frequency you'd like to specify with the SLA. Required when the `object_type` is `mssql_host`. (default {None})
+            log_retention_hours {int} -- The MSSQL or Oracle Log Retention frequency you'd like to specify with the SLA. Required when the `object_type` is `mssql_host`, `oracle_db` or 'oracle_host'. (default {None})
+            copy_only {bool} -- Take Copy Only Backups with MSSQL. Required when the `object_type` is `mssql_host`. (default {None})
             windows_host {str} -- The name of the Windows host that contains the relevant volume group. Required when the `object_type` is `volume_group`. (default {None})
             nas_host {str} -- The name of the NAS host that contains the relevant share. Required when the `object_type` is `fileset`. (default {None})
             share {str} -- The name of the network share a fileset will be created for. Required when the `object_type` is `fileset`. (default {None})
-            timeout {bool} -- The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. (default: {30})
+            log_backup_frequency_in_minutes {int} - The Oracle Log Backup frequency you'd like to specify with the SLA. Required when the `object_type` is `oracle_db` or `oracle_host`. (default {None})
+            num_channels {int} - Number of RMAN channels used to backup the Oracle database. Required when the `object_type` is `oracle_host`. (default {"4""})
+            hostname {str} -- The hostname, or one of the hostnames in a RAC cluster, or the RAC cluster name. Required when the object_type is `oracle_db`. (default {None})
+            timeout {int} -- The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. (default: {30})
         Returns:
             str -- No change required. The vSphere VM '`object_name`' is already assigned to the '`sla_name`' SLA Domain.
             str -- No change required. The MSSQL Instance '`object_name`' is already assigned to the '`sla_name`' SLA Domain with the following log settings: log_backup_frequency_in_seconds: `log_backup_frequency_in_seconds`, log_retention_hours: `log_retention_hours` and copy_only: `copy_only`
+            str -- No change required. The Oracle Database '`object_name`' is already assigned to the '`sla_name`' SLA Domain with the following log settings: log_backup_frequency_in_minutes: `log_backup_frequency_in_seconds`, log_retention_hours: `log_retention_hours` and num_channels: `num_channels`.
+            str -- No change required. The Oracle Host '`object_name`' is already assigned to the '`sla_name`' SLA Domain with the following log settings: log_backup_frequency_in_seconds: `log_backup_frequency_in_seconds`. log_retention_hours: `log_retention_hours`, and num_channels: `num_channels`
             str -- No change required. The '`object_name`' volume_group is already assigned to the '`sla_name`' SLA Domain.
             dict -- The full API response for `POST /internal/sla_domain/{sla_id}/assign`.
             dict -- The full API response for `PATCH /internal/volume_group/{id}`.
+            dict -- The full API response for `PATCH /internal/oracle/db/{id}.`
+            dict -- The full API response for `PATCH /internal/oracle/host/{id}`.
         """
 
         self.function_name = inspect.currentframe().f_code.co_name
 
-        valid_object_type = ['vmware', 'mssql_host', 'volume_group', 'fileset', 'ahv']
+        valid_object_type = ['vmware', 'mssql_host', 'volume_group', 'fileset', 'ahv', 'oracle_db', 'oracle_host']
 
         if object_type not in valid_object_type:
             raise InvalidParameterException(
@@ -490,6 +502,16 @@ class Data_Management(Api):
             if log_backup_frequency_in_seconds is None or log_retention_hours is None or copy_only is None:
                 raise InvalidParameterException(
                     "When the object_type is 'mssql_host' the 'log_backup_frequency_in_seconds', 'log_retention_hours', 'copy_only' paramaters must be populated.")
+
+        if object_type == "oracle_host":
+            if log_backup_frequency_in_minutes is None or log_retention_hours is None or num_channels is None:
+                raise InvalidParameterException(
+                    "When the object_type is 'oracle_host' the 'log_backup_frequency_in_minutes', 'log_retention_hours', 'num_channels' paramaters must be populated.")                    
+
+        if object_type == "oracle_db":
+            if log_backup_frequency_in_minutes is None or log_retention_hours is None or num_channels is None or hostname is None:
+                raise InvalidParameterException(
+                    "When the object_type is 'oracle_db' the 'log_backup_frequency_in_minutes', 'log_retention_hours', 'num_channels' and 'hostname' paramaters must be populated.")    
 
         if object_type == "fileset":
             if nas_host is None or share is None:
@@ -665,6 +687,98 @@ class Data_Management(Api):
                     "Host ID not found for instance '{}'").format(object_name)
 
             return db_sla_lst
+
+        elif object_type == 'oracle_db':
+
+            oracle_db_id = ''
+            db_sla_lst = []
+
+            self.log('Searching the Rubrik cluster for the current Oracle databases.')
+            oracle_db_id = self.object_id(object_name, object_type, hostname=hostname)
+
+            if(oracle_db_id):
+                self.log(
+                    "assign_sla: Determing the SLA Domain currently assigned to the Oracle Database '{}'.".format(object_name))
+
+                oracle_summary = self.get(
+                    'internal',
+                    '/oracle/db/{}'.format(oracle_db_id),
+                    timeout=timeout)
+
+                if (sla_id == oracle_summary['configuredSlaDomainId'] and log_backup_frequency_in_minutes == oracle_summary['logBackupFrequencyInMinutes'] and
+                        log_retention_hours == oracle_summary['logRetentionHours'] and num_channels == oracle_summary['numChannels']):
+                    return "No change required. The Oracle Database '{}' is already assigned to the '{}' SLA Domain with the following log settings:" \
+                            " log_backup_frequency_in_minutes: {}, log_retention_hours: {} and num_channels: {}.".format(
+                                object_name, sla_name, log_backup_frequency_in_minutes, log_retention_hours, num_channels)
+
+                else:
+                    self.log(
+                        "assign_sla: Assigning the Oracle Database '{}' to the '{}' SLA Domain.".format(
+                            object_name, sla_name))
+
+                    config = {}
+                    if log_backup_frequency_in_minutes is not None:
+                        config['logBackupFrequencyInMinutes'] = log_backup_frequency_in_minutes
+                    if log_retention_hours is not None:
+                        config['logRetentionHours'] = log_retention_hours
+                    if num_channels is not None:
+                        config['numChannels'] = num_channels
+
+                    config['configuredSlaDomainId'] = sla_id
+
+                    patch_resp = self.patch("internal", "/oracle/db/{}".format(oracle_db_id), config, timeout)
+                    db_sla_lst.append(patch_resp)
+            else:
+                raise InvalidParameterException(
+                    "Database ID not found for instance '{}'").format(object_name)
+            
+            return db_sla_lst
+
+        elif object_type == 'oracle_host':
+
+            host_id = ''
+            db_sla_lst = []
+
+            self.log('Searching the Rubrik cluster for the current Oracle hosts.')
+            host_id = self.object_id(object_name, object_type)
+
+            if(host_id):
+                self.log(
+                    "assign_sla: Determing the SLA Domain currently assigned to the Oracle Host '{}'.".format(object_name))
+
+                oracle_summary = self.get(
+                    'internal',
+                    '/oracle/host/{}'.format(host_id),
+                    timeout=timeout)
+
+                if (sla_id == oracle_summary['configuredSlaDomainId'] and log_backup_frequency_in_minutes == oracle_summary['logBackupFrequencyInMinutes'] and
+                        log_retention_hours == oracle_summary['logRetentionHours'] and num_channels == oracle_summary['numChannels']):
+                    return "No change required. The Oracle Host '{}' is already assigned to the '{}' SLA Domain with the following log settings:" \
+                            " log_backup_frequency_in_minutes: {}, log_retention_hours: {} and num_channels: {}.".format(
+                                object_name, sla_name, log_backup_frequency_in_minutes, log_retention_hours, num_channels)
+
+                else:
+                    self.log(
+                        "assign_sla: Assigning the Oracle Host '{}' to the '{}' SLA Domain.".format(
+                            object_name, sla_name))
+
+                    config = {}
+                    if log_backup_frequency_in_minutes is not None:
+                        config['logBackupFrequencyInMinutes'] = log_backup_frequency_in_minutes
+                    if log_retention_hours is not None:
+                        config['logRetentionHours'] = log_retention_hours
+                    if num_channels is not None:
+                        config['numChannels'] = num_channels
+
+                    config['configuredSlaDomainId'] = sla_id
+
+                    patch_resp = self.patch("internal", "/oracle/host/{}".format(host_id), config, timeout)
+                    db_sla_lst.append(patch_resp)
+            else:
+                raise InvalidParameterException(
+                    "Host ID not found for instance '{}'").format(object_name)
+
+            return db_sla_lst            
 
         elif object_type == "volume_group":
 

--- a/rubrik_cdm/data_management.py
+++ b/rubrik_cdm/data_management.py
@@ -628,6 +628,7 @@ class Data_Management(Api):
 
             host_id = ''
             mssql_id = ''
+            db_sla_lst = []
 
             self.log('Searching the Rubrik cluster for the current hosts.')
             current_hosts = self.get(
@@ -680,11 +681,12 @@ class Data_Management(Api):
                         config['configuredSlaDomainId'] = sla_id
 
                         patch_resp = self.patch("v1", "/mssql/instance/{}".format(mssql_id), config, timeout)
+                        db_sla_lst.append(patch_resp)
             else:
                 raise InvalidParameterException(
                     "Host ID not found for instance '{}'").format(object_name)
 
-            return patch_resp
+            return db_sla_lst
 
         elif object_type == 'oracle_db':
 
@@ -733,7 +735,6 @@ class Data_Management(Api):
         elif object_type == 'oracle_host':
 
             host_id = ''
-            db_sla_lst = []
 
             self.log('Searching the Rubrik cluster for the current Oracle hosts.')
             host_id = self.object_id(object_name, object_type)
@@ -769,12 +770,11 @@ class Data_Management(Api):
                     config['configuredSlaDomainId'] = sla_id
 
                     patch_resp = self.patch("internal", "/oracle/host/{}".format(host_id), config, timeout)
-                    db_sla_lst.append(patch_resp)
             else:
                 raise InvalidParameterException(
                     "Host ID not found for instance '{}'").format(object_name)
 
-            return db_sla_lst            
+            return patch_resp           
 
         elif object_type == "volume_group":
 

--- a/sample/assign_sla.py
+++ b/sample/assign_sla.py
@@ -33,6 +33,56 @@ assignsla = rubrik.assign_sla(
     copyOnly)
 
 
+# Oracle Database
+
+
+import rubrik_cdm
+
+rubrik = rubrik_cdm.Connect()
+
+object_name = 'HRDB50'
+object_type = 'oracle_db'
+hostname = 'python-sdk.demo.com'
+
+sla_name = 'Gold'
+log_backup_frequency_in_minutes = 30
+log_retention_hours = 720
+num_channels = 4
+
+assignsla = rubrik.assign_sla(
+    object_name, 
+    sla_name, 
+    object_type, 
+    log_backup_frequency_in_minutes=log_backup_frequency_in_minutes, 
+    log_retention_hours=log_retention_hours, 
+    num_channels=num_channels,
+    hostname=hostname)
+
+
+# Oracle Host
+
+
+import rubrik_cdm
+
+rubrik = rubrik_cdm.Connect()
+
+object_name = 'python-sdk.demo.com'
+object_type = 'oracle_host'
+
+sla_name = 'Gold'
+log_backup_frequency_in_minutes = 30
+log_retention_hours = 720
+num_channels = 4
+
+assignsla = rubrik.assign_sla(
+    object_name, 
+    sla_name, 
+    object_type, 
+    log_backup_frequency_in_minutes=log_backup_frequency_in_minutes, 
+    log_retention_hours=log_retention_hours, 
+    num_channels=num_channels)
+
+
 # Volume Group
 
 

--- a/tests/unit/data_management_test.py
+++ b/tests/unit/data_management_test.py
@@ -1722,7 +1722,7 @@ def test_object_id_invalid_object_type(rubrik):
 
     error_message = error.value.args[0]
 
-    assert error_message == "The object_id() object_type argument must be one of the following: ['vmware', 'sla', 'vmware_host', 'physical_host', 'fileset_template', 'managed_volume', 'mssql_db', 'mssql_instance', 'vcenter', 'ahv', 'aws_native', 'oracle_db', 'volume_group', 'archival_location', 'share']."
+    assert error_message == "The object_id() object_type argument must be one of the following: ['vmware', 'sla', 'vmware_host', 'physical_host', 'fileset_template', 'managed_volume', 'mssql_db', 'mssql_instance', 'vcenter', 'ahv', 'aws_native', 'oracle_db', 'oracle_host', 'volume_group', 'archival_location', 'share']."
 
 
 def test_object_id_invalid_fileset_template(rubrik):
@@ -2625,7 +2625,7 @@ def test_assign_sla_invalid_object_type(rubrik):
 
     error_message = error.value.args[0]
 
-    assert error_message == "The assign_sla() object_type argument must be one of the following: ['vmware', 'mssql_host', 'volume_group', 'fileset', 'ahv']."
+    assert error_message == "The assign_sla() object_type argument must be one of the following: ['vmware', 'mssql_host', 'volume_group', 'fileset', 'ahv', 'oracle_db', 'oracle_host']."
 
 
 def test_assign_sla_idempotence_specific_sla(rubrik, mocker):


### PR DESCRIPTION
# Description

* Add Oracle DB and Oracle Host support to assign_sla()
* Add Oracle Host support to object_id()

## Related Issue

#144 

## Motivation and Context

Customer need to programmatically assign SLAs to Oracle Databases

## How Has This Been Tested?

* Manual testing against Rubrik CDM 5.0

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/rubrik-sdk-for-python/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
