### PR TITLE
Replaced create_docs.py markdown generation with jinja2 templates

### DIFF
--- a/docs/templates/SUMMARY.md.j2
+++ b/docs/templates/SUMMARY.md.j2
@@ -1,0 +1,55 @@
+# Summary
+
+### Getting Started
+
+* [Quick Start](README.md)
+
+### Base API Calls
+
+{% for fn in base_functions %}
+* [{{ fn[0] }}]({{ fn[0] }}.md)
+{% endfor %}
+
+### Bootstrap Functions
+
+{% for fn in bootstrap_functions %}
+* [{{ fn[0] }}]({{ fn[0] }}.md)
+{% endfor %}
+
+### Cluster Functions
+
+{% for fn in cluster_functions %}
+* [{{ fn[0] }}]({{ fn[0] }}.md)
+{% endfor %}
+
+### Cloud Functions
+
+{% for fn in cloud_functions %}
+* [{{ fn[0] }}]({{ fn[0] }}.md)
+{% endfor %}
+
+### Data Management Functions
+
+{% for fn in data_management_functions %}
+* [{{ fn[0] }}]({{ fn[0] }}.md)
+{% endfor %}
+
+### Physical Host Functions
+
+{% for fn in physical_functions %}
+* [{{ fn[0] }}]({{ fn[0] }}.md)
+{% endfor %}
+
+### SDK Helper Functions
+
+{% for fn in helper_functions %}
+* [{{ fn[0] }}]({{ fn[0] }}.md)
+{% endfor %}
+* [exceptions](exceptions.md)
+
+### Internal Functions
+
+{% for fn in internal_functions %}
+* [{{ fn[0] }}]({{ fn[0] }}.md)
+{% endfor %}
+

--- a/docs/templates/function.md.j2
+++ b/docs/templates/function.md.j2
@@ -1,0 +1,41 @@
+# {{ name }}
+
+{{ description }}
+
+{% if arguments %}
+## Arguments
+
+| Name        | Type | Description                                                                 | Choices |
+|-------------|------|-----------------------------------------------------------------------------|---------|
+{% for arg in arguments %}
+| {{ arg.name }} | {{ arg.type }} | {{ arg.description }} | {{ arg.choices }} |
+{% endfor %}
+{% endif %}
+
+{% if keyword_arguments %}
+## Keyword Arguments
+
+| Name        | Type | Description                                                                 | Choices | Default |
+|-------------|------|-----------------------------------------------------------------------------|---------|---------|
+{% for arg in keyword_arguments %}
+| {{ arg.name }} | {{ arg.type }} | {{ arg.description }} | {{ arg.choices }} | {{ arg.default }} |
+{% endfor %}
+{% endif %}
+
+{% if returns %}
+## Returns
+
+| Type | Return Value                                                                                  |
+|------|-----------------------------------------------------------------------------------------------|
+{% for r in returns %}
+| {{ r.type }} | {{ r.description }} |
+{% endfor %}
+{% endif %}
+
+{% if example -%}
+## Example
+
+```py
+{{ example }}
+```
+{% endif %}


### PR DESCRIPTION
# Description

Use jinja2 to template the markdown doc files.

## Related Issue

## Motivation and Context

Improve maintainability of the create_docs.py script and moves output format changes out to template files instead of the script itself.

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/rubrik-sdk-for-python/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
