### PR TITLE
Fix error with HTTP 204 response

### DIFF
--- a/docs/delete_sla.md
+++ b/docs/delete_sla.md
@@ -1,0 +1,26 @@
+# delete_sla
+
+Delete an SLA from the Rubrik Cluster
+
+```py
+def delete_sla(self, name, timeout=15):
+```
+
+## Arguments
+
+| Name        | Type | Description                                                                 | Choices |
+|-------------|------|-----------------------------------------------------------------------------|---------|
+| name  | [type] | The name of the SLA you wish to delete. |  |
+
+## Keyword Arguments
+
+| Name        | Type | Description                                                                 | Choices | Default |
+|-------------|------|-----------------------------------------------------------------------------|---------|---------|
+| timeout  | int | The number of seconds to wait to establish a connection to the Rubrik cluster.  |  | 15 |
+
+## Returns
+
+| Type | Return Value                                                                                  |
+|------|-----------------------------------------------------------------------------------------------|
+| dict | The full API response for `DELETE /v1/sla_domain`. |
+

--- a/rubrik_cdm/api.py
+++ b/rubrik_cdm/api.py
@@ -136,17 +136,19 @@ class Api():
 
             self.log(str(api_request) + "\n")
             try:
-                api_response = api_request.json()
-                # Check to see if an error message has been provided by Rubrik
-                for key, value in api_response.items():
-                    if key == "errorType" or key == 'message':
-                        error_message = api_response['message']
-                        api_request.raise_for_status()
+                # request.json() will fail on a 204 (No Content) so skip the response check
+                if api_request.status_code != 204:
+                    api_response = api_request.json()
+                    # Check to see if an error message has been provided by Rubrik
+                    for key, value in api_response.items():
+                        if key == "errorType" or key == 'message':
+                            error_message = api_response['message']
+                            api_request.raise_for_status()
 
-                    # Check for GQL error message in the data response
-                    if key == "error":
-                        error_message = api_response['error']
-                        api_request.raise_for_status()
+                        # Check for GQL error message in the data response
+                        if key == "error":
+                            error_message = api_response['error']
+                            api_request.raise_for_status()
 
             except BaseException:
                 api_request.raise_for_status()
@@ -188,8 +190,12 @@ class Api():
                             return api_request.json()["data"]
                         except BaseException:
                             pass
-
-                return api_request.json()
+                
+                # request.json() will fail on a 204 (No Content), so return an empty string
+                if api_request.status_code != 204:
+                    return api_request.json()
+                else:
+                    return ""
             except BaseException:
                 raise APICallException(error_message)
                 return {'status_code': api_request.status_code}

--- a/rubrik_cdm/api.py
+++ b/rubrik_cdm/api.py
@@ -184,20 +184,19 @@ class Api():
                 if call_type == "QUERY":
                     try:
                         error_message
-                        raise BaseException
+                        raise APICallException(error_message)
                     except NameError:
                         try:
                             return api_request.json()["data"]
                         except BaseException:
                             pass
                 
-                # request.json() will fail on a 204 (No Content), so return an empty string
+                # request.json() will fail on a 204 (No Content), so just the response code
                 if api_request.status_code != 204:
                     return api_request.json()
                 else:
-                    return ""
+                    return {'status_code': api_request.status_code}
             except BaseException:
-                raise APICallException(error_message)
                 return {'status_code': api_request.status_code}
 
     def get(self, api_version, api_endpoint, timeout=15, authentication=True, params=None):


### PR DESCRIPTION
# Description

API calls that result in an HTTP 204 (no content) response may raise an error due to a call to api_request.json() call. This PR adds a check to make sure api_request.json() is not called when an HTTP 204 response (no content) is returned.

Also, one doc file (delete_sla) was missing, so it is included in this PR

## Related Issue

#210 

## Motivation and Context

Why is this change required? What problem does it solve? Bug fix

## How Has This Been Tested?

* Manual testing
* Unit tests passing

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/rubrik-sdk-for-python/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
