### PR TITLE
Fixed case-sensitivity for object_id query

### DIFF
--- a/rubrik_cdm/data_management.py
+++ b/rubrik_cdm/data_management.py
@@ -453,7 +453,7 @@ class Data_Management(Api):
                 elif object_type == 'share' and item[name_value] == object_name:
                     if item['hostId'] == host_id:
                         object_ids.append(item['id'])
-                elif item[name_value] == object_name:
+                elif item[name_value].casefold() == object_name.casefold():
                     object_ids.append(item['id'])
             if len(object_ids) > 1:
                 raise InvalidParameterException(

--- a/rubrik_cdm/data_management.py
+++ b/rubrik_cdm/data_management.py
@@ -453,7 +453,7 @@ class Data_Management(Api):
                 elif object_type == 'share' and item[name_value] == object_name:
                     if item['hostId'] == host_id:
                         object_ids.append(item['id'])
-                elif item[name_value].casefold() == object_name.casefold():
+                elif item[name_value].lower() == object_name.lower():
                     object_ids.append(item['id'])
             if len(object_ids) > 1:
                 raise InvalidParameterException(


### PR DESCRIPTION
# Description

When quering for a vm by name capitalization does not matter as the vm endpoint is caps insensitive. However when querying by .object_id() the query fails if the exact capitalization does not match the output of respective the api endpoint

## Related Issue

Resolve #216 

## Motivation and Context

getobject_id is case sensitive, where the api endpoints are not.

## How Has This Been Tested?

Tested this against 5.1 / 5.2 clusters

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/rubrik-sdk-for-python/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
