### PR TITLE
Add unit tests for logging

### DIFF
--- a/tests/unit/rubrik_cdm_test.py
+++ b/tests/unit/rubrik_cdm_test.py
@@ -1,4 +1,6 @@
 import pytest
+import logging
+import rubrik_cdm
 
 
 def test_unit_header(rubrik):
@@ -20,3 +22,55 @@ def test_validate_release_version_matches_user_agent_version(rubrik):
                 release_version = line_content.strip().replace('version="', "").replace('",', "")
 
     assert release_version == rubrik.sdk_version
+
+def test_logging_output(mocker, caplog):
+
+    def mock_get_v1_cluster_me_version():
+        return {'version': '5.0.1-1280'}
+
+    mock_get = mocker.patch('rubrik_cdm.Connect.get', autospec=True, spec_set=True)
+    mock_get.return_value = mock_get_v1_cluster_me_version()
+
+    # Manually import rubrik_cdm instead of using the fixture to get proper log
+    # message count and to more easily set logging level
+    rubrik = rubrik_cdm.Connect("10.0.1.1", "user", "password", enable_logging=True)
+
+    rubrik.cluster_version()
+
+    assert len(caplog.records) == 4
+
+    log_entries = {
+        0: "Node IP: 10.0.1.1",
+        1: "Username: user",
+        2: "Password: ******",
+        3: "cluster_version: Getting the software version of the Rubrik cluster."
+    }
+
+    for index, log_message in log_entries.items():
+        assert caplog.records[index].message == log_message
+    
+@pytest.mark.parametrize('logging_level', ["debug", "critical", "error", "warning", "info"])
+def test_logging_level(mocker, caplog, logging_level):
+
+    def mock_get_v1_cluster_me_version():
+        return {'version': '5.0.1-1280'}
+
+    mock_get = mocker.patch('rubrik_cdm.Connect.get', autospec=True, spec_set=True)
+    mock_get.return_value = mock_get_v1_cluster_me_version()
+
+    # Manually import rubrik_cdm instead of using the fixture to get proper log
+    # message count and to more easily set logging level
+    rubrik = rubrik_cdm.Connect("10.0.1.1", "user", "password", enable_logging=True, logging_level=logging_level)
+
+    rubrik.cluster_version()
+    
+    # Validate the logging level
+    set_logging = {
+            "debug": logging.DEBUG,
+            "critical": logging.CRITICAL,
+            "error": logging.ERROR,
+            "warning": logging.WARNING,
+            "info": logging.INFO,
+        }
+        
+    assert caplog.records[0].levelno == set_logging[logging_level]

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@
 envlist = py27, py37
 
 [testenv]
-commands = pytest -rf tests/unit
+commands = pytest -rf --tb short tests/unit
 deps =
     pytest >= 3.6.2
     pytest-mock >= 1.10.3


### PR DESCRIPTION
# Description

* Adds unit tests to previously submitted logging enhancements
* Updates pytest to use the `--tb short`. This prevents the full function code from being shown in errors which makes the output difficult to rad

## Motivation and Context

Needed unit tests for logging

## How Has This Been Tested?

```
tests/unit/rubrik_cdm_test.py::test_unit_header PASSED                          [ 12%]
tests/unit/rubrik_cdm_test.py::test_validate_release_version_matches_user_agent_version PASSED [ 25%]
tests/unit/rubrik_cdm_test.py::test_logging_output PASSED                       [ 37%]
tests/unit/rubrik_cdm_test.py::test_logging_level[debug] PASSED                 [ 50%]
tests/unit/rubrik_cdm_test.py::test_logging_level[critical] PASSED              [ 62%]
tests/unit/rubrik_cdm_test.py::test_logging_level[error] PASSED                 [ 75%]
tests/unit/rubrik_cdm_test.py::test_logging_level[warning] PASSED               [ 87%]
tests/unit/rubrik_cdm_test.py::test_logging_level[info] PASSED                  [100%]
```
## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


