### PR TITLE
correctly handle special characters in request values

### DIFF
--- a/rubrik_cdm/api.py
+++ b/rubrik_cdm/api.py
@@ -72,9 +72,8 @@ class Api():
             if call_type == 'GET':
                 request_url = "https://{}/api/{}{}".format(self.node_ip, api_version, api_endpoint)
                 if params is not None:
-                    request_url = request_url + "?" + '&'.join("{}={}".format(key, val)
+                    request_url = request_url + "?" + '&'.join("{}={}".format(key, quote(val))
                                                                for (key, val) in params.items())
-                request_url = quote(request_url, '://?=&[]')
                 self.log('GET {}'.format(request_url))
                 api_request = requests.get(
                     request_url, verify=False, headers=header, timeout=timeout)


### PR DESCRIPTION
# Description

Moved the `quote` to specifically function on values instead of the URI as a whole. This removes the need to ignore encoding of certain characters as URI formation is done with the pre-encoded strings.

## Related Issue

https://github.com/rubrikinc/rubrik-sdk-for-python/issues/227

## Motivation and Context

The change is necessary to correctly encode special characters. The second quote line becomes redundant and unnecessary. 

## How Has This Been Tested?

Tested using multiple GET requests

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/rubrik-sdk-for-python/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
