### PR TITLE
Improve create_sla() error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## Changed
+
+- The create_sla() function will return a more clear error message when the SLA was found on the Rubrik cluster but with a different configuraiton than the one provided. ([Issue 236](https://github.com/rubrikinc/rubrik-sdk-for-python/issues/236))
+
 ## Fixed
 
 - When calling create_sla() an error will not longer be thrown for frequencies and retentions that have a default None value provided ([Issue 232](https://github.com/rubrikinc/rubrik-sdk-for-python/issues/232))

--- a/rubrik_cdm/data_management.py
+++ b/rubrik_cdm/data_management.py
@@ -806,7 +806,6 @@ class Data_Management(Api):
                 raise InvalidParameterException(
                     "Database ID not found for instance '{}'".format(object_name))
 
-
             return patch_resp
 
         elif object_type == 'oracle_host':
@@ -1551,7 +1550,7 @@ class Data_Management(Api):
                     name)
             else:
                 raise InvalidParameterException(
-                    "The Rubrik cluster already has an SLA Domain named '{}'.".format(name))
+                    "The Rubrik cluster already has an SLA Domain named '{}' whose configuration does not match the values provided.".format(name))
 
         self.log("create_sla: Creating the new SLA")
         if v2_sla is True:


### PR DESCRIPTION
# Description

Update the `create_sla()` error message to `The Rubrik cluster already has an SLA Domain named '{}' whose configuration does not match the values provided.`

## Related Issue

https://github.com/rubrikinc/rubrik-sdk-for-python/issues/236

## How Has This Been Tested?

* Gaia integration test. See screenshot below

## Screenshots (if appropriate):

```
Traceback (most recent call last):
  File "dev.py", line 13, in <module>
    rubrik.create_sla("PythonSDKTest", hourly_frequency=1, hourly_retention=2)
  File "/Users/drewrussell/Development/rubrik-sdk-for-python/rubrik_cdm/data_management.py", line 1553, in create_sla
    "The Rubrik cluster already has an SLA Domain named '{}' whose configuration does not match the values provided.".format(name))
rubrik_cdm.exceptions.InvalidParameterException: The Rubrik cluster already has an SLA Domain named 'PythonSDKTest' whose configuration does not match the values provided.
```

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

