### PR TITLE
Add functionality for Nutanix AHV cluster refreshes

### DIFF
--- a/docs/_build/refresh_ahv.md
+++ b/docs/_build/refresh_ahv.md
@@ -1,0 +1,41 @@
+# refresh_ahv
+
+Refresh the metadata for the specified Nutanix AHV cluster.
+
+```py
+def refresh_ahv(self, nutanix_ahv_cluster, wait_for_completion=True, timeout=15):
+```
+
+## Arguments
+
+| Name        | Type | Description                                                                 | Choices |
+|-------------|------|-----------------------------------------------------------------------------|---------|
+| nutanix_ahv_cluster | str | The name of the AHV cluster you wish to refresh. |  |
+
+## Keyword Arguments
+
+| Name        | Type | Description                                                                 | Choices | Default |
+|-------------|------|-----------------------------------------------------------------------------|---------|---------|
+| wait_for_completion  | bool | Flag to determine if the function should wait for the refresh to complete before completing.  |  | True |
+| timeout  | int | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error.  |  | 15 |
+
+## Returns
+
+| Type | Return Value                                                                                  |
+|------|-----------------------------------------------------------------------------------------------|
+| dict | When wait_for_completion is False, the full API response for `POST /internal/nutanix/cluster/{id}/refresh` |
+| dict | When wait_for_completion is True, the full API response of the job status |
+
+
+
+## Example
+
+```py
+import rubrik_cdm
+rubrik = rubrik_cdm.Connect()
+
+nutanix_ahv_hostname = "ahvcluster"
+refresh_ahv = rubrik.refresh_ahv(nutanix_ahv_hostname)
+print(refresh_ahv)
+
+```

--- a/rubrik_cdm/cluster.py
+++ b/rubrik_cdm/cluster.py
@@ -751,6 +751,37 @@ class Cluster(Api):
 
         return api_request
 
+    def refresh_ahv(self, nutanix_ahv_ip, wait_for_completion=True, timeout=15):
+        """Refresh the metadata for the specified Nutanix AHV cluster.
+
+        Arguments:
+            nutanix_ahv_ip {str} -- The IP address or FQDN of the AHV cluster you wish to refesh.
+
+
+        Keyword Arguments:
+            wait_for_completion {bool} -- Flag to determine if the function should wait for the refresh to complete before completing. (default: {True})
+            timeout {int} -- The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. (default: {15})
+
+        Returns:
+            dict -- When wait_for_completion is False, the full API response for `POST /internal/ahv/cluster/{id}/refresh`
+            dict -- When wait_for_completion is True, the full API response of the job status
+        """
+
+        self.function_name = inspect.currentframe().f_code.co_name
+
+        self.log(
+            "refresh_ahv: Searching the Rubrik cluster for the provided AHV cluster.")
+        ahv_id = self.object_id(nutanix_ahv_ip, "ahv", timeout=timeout)
+
+        self.log("refresh_ahv: Refresh AHV cluster.")
+        api_request = self.post(
+            "internal", "/ahv/cluster/{}/refresh".format(ahv_id), timeout)
+
+        if wait_for_completion:
+            return self.job_status(api_request["links"][0]["href"])
+
+        return api_request
+
     def update_proxy(self, host, protocol, port, username=None, password=None, timeout=15):
         """Update the proxy configuration on the Rubrik cluster.
 

--- a/rubrik_cdm/cluster.py
+++ b/rubrik_cdm/cluster.py
@@ -763,7 +763,7 @@ class Cluster(Api):
             timeout {int} -- The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. (default: {15})
 
         Returns:
-            dict -- When wait_for_completion is False, the full API response for `POST /internal/ahv/cluster/{id}/refresh`
+            dict -- When wait_for_completion is False, the full API response for `POST /internal/nutanix/cluster/{id}/refresh`
             dict -- When wait_for_completion is True, the full API response of the job status
         """
 

--- a/rubrik_cdm/cluster.py
+++ b/rubrik_cdm/cluster.py
@@ -775,7 +775,7 @@ class Cluster(Api):
 
         self.log("refresh_ahv: Refresh AHV cluster.")
         api_request = self.post(
-            "internal", "/ahv/cluster/{}/refresh".format(ahv_id), timeout)
+            "internal", "/nutanix/cluster/{}/refresh".format(ahv_id), timeout)
 
         if wait_for_completion:
             return self.job_status(api_request["links"][0]["href"])

--- a/rubrik_cdm/cluster.py
+++ b/rubrik_cdm/cluster.py
@@ -771,7 +771,7 @@ class Cluster(Api):
 
         self.log(
             "refresh_ahv: Searching the Rubrik cluster for the provided AHV cluster.")
-        ahv_id = self.object_id(nutanix_ahv_ip, "ahv", timeout=timeout)
+        ahv_id = self.object_id(nutanix_ahv_ip, "ahv_cluster", timeout=timeout)
 
         self.log("refresh_ahv: Refresh AHV cluster.")
         api_request = self.post(

--- a/rubrik_cdm/cluster.py
+++ b/rubrik_cdm/cluster.py
@@ -751,11 +751,11 @@ class Cluster(Api):
 
         return api_request
 
-    def refresh_ahv(self, nutanix_ahv_ip, wait_for_completion=True, timeout=15):
+    def refresh_ahv(self, nutanix_ahv_cluster, wait_for_completion=True, timeout=15):
         """Refresh the metadata for the specified Nutanix AHV cluster.
 
         Arguments:
-            nutanix_ahv_ip {str} -- The IP address or FQDN of the AHV cluster you wish to refesh.
+            nutanix_ahv_cluster {str} -- The name of the AHV cluster you wish to refresh.
 
 
         Keyword Arguments:
@@ -771,7 +771,7 @@ class Cluster(Api):
 
         self.log(
             "refresh_ahv: Searching the Rubrik cluster for the provided AHV cluster.")
-        ahv_id = self.object_id(nutanix_ahv_ip, "ahv_cluster", timeout=timeout)
+        ahv_id = self.object_id(nutanix_ahv_cluster, "ahv_cluster", timeout=timeout)
 
         self.log("refresh_ahv: Refresh AHV cluster.")
         api_request = self.post(

--- a/rubrik_cdm/data_management.py
+++ b/rubrik_cdm/data_management.py
@@ -337,6 +337,7 @@ class Data_Management(Api):
             'mssql_availability_group',
             'vcenter',
             'ahv',
+            'ahv_cluster',
             'aws_native',
             'oracle_db',
             'oracle_host',
@@ -417,6 +418,10 @@ class Data_Management(Api):
             "ahv": {
                 "api_version": "internal",
                 "api_endpoint": "/nutanix/vm?primary_cluster_id=local&is_relic=false&name={}".format(object_name)
+            },
+            "ahv_cluster": {
+                "api_version": "internal",
+                "api_endpoint": "/nutanix/cluster?primary_cluster_id=local".format(object_name)
             },
             "aws_native": {
                 "api_version": "internal",
@@ -1691,7 +1696,7 @@ class Data_Management(Api):
         if replication_target is not None:
             replication_target_id = self.object_id(
                 replication_target, "replication_location", timeout=timeout)
-            
+
             # convert remote retention in days to seconds
             replication_retention_in_seconds = replication_retention_in_days * 86400
             config["replicationSpecs"] = [{
@@ -1740,7 +1745,7 @@ class Data_Management(Api):
             if archive_name is not None:
                 keys_to_delete.remove("archivalSpecs")
                 current_sla_details["localRetentionLimit"] = archival_threshold
-            
+
             if starttime_hour is not None:
                 keys_to_delete.remove("allowedBackupWindows")
 

--- a/sample/refresh_ahv.py
+++ b/sample/refresh_ahv.py
@@ -1,8 +1,8 @@
 import rubrik_cdm
 rubrik = rubrik_cdm.Connect()
 
-nutanix_ahv_hostname = "ahv.example.com"
+nutanix_ahv_cluster_name = "ahvcluster"
 
-refresh = rubrik.refresh_ahv(nutanix_ahv_hostname)
+refresh = rubrik.refresh_ahv(nutanix_ahv_cluster_name)
 
 print(refresh)

--- a/sample/refresh_ahv.py
+++ b/sample/refresh_ahv.py
@@ -1,0 +1,8 @@
+import rubrik_cdm
+rubrik = rubrik_cdm.Connect()
+
+nutanix_ahv_hostname = "ahv.example.com"
+
+refresh = rubrik.refresh_ahv(nutanix_ahv_hostname)
+
+print(refresh)

--- a/tests/unit/data_management_test.py
+++ b/tests/unit/data_management_test.py
@@ -1750,7 +1750,7 @@ def test_object_id_invalid_object_type(rubrik):
 
     error_message = error.value.args[0]
 
-    assert error_message == "The object_id() object_type argument must be one of the following: ['vmware', 'sla', 'vmware_host', 'physical_host', 'fileset_template', 'managed_volume', 'mssql_db', 'mssql_instance', 'mssql_availability_group', 'vcenter', 'ahv', 'aws_native', 'oracle_db', 'oracle_host', 'volume_group', 'archival_location', 'share', 'organization', 'organization_role_id', 'organization_admin_role', 'replication_location']."
+    assert error_message == "The object_id() object_type argument must be one of the following: ['vmware', 'sla', 'vmware_host', 'physical_host', 'fileset_template', 'managed_volume', 'mssql_db', 'mssql_instance', 'mssql_availability_group', 'vcenter', 'ahv', 'ahv_cluster', 'aws_native', 'oracle_db', 'oracle_host', 'volume_group', 'archival_location', 'share', 'organization', 'organization_role_id', 'organization_admin_role', 'replication_location']."
 
 
 def test_object_id_invalid_fileset_template(rubrik):


### PR DESCRIPTION
# Description

I've added functionality to trigger a Nutanix AHV cluster refresh to the SDK.

## Related Issue

This project only accepts pull requests related to open issues.

* If suggesting a new feature or change, please discuss it in an issue first.
* If fixing a bug, there should be an issue describing it with steps to reproduce

#266 

## Motivation and Context

Allows Nutanix AHV clusters to be refreshed using the SDK.  This could also be used in a new Ansible module, which is still being worked on.

## How Has This Been Tested?

Tested with Python 3.7.3, Rubrik 5.2.2 p2, and Nutanix 5.18.1.2.  The Nutanix cluster refresh appears to work properly with a status of SUCCEEDED.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [ ] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/rubrik-sdk-for-python/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

I'm afraid I'm somewhat of the "newbie" mentioned in the readme, so I didn't see any testing protocols to follow.  If there's anything that's needed on my end please let me know.
