### PR TITLE
[Windows Python 2/3] MSSQL Recovery Point Validation TypeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - The `object_id()` function now returns the correct the MSSQL DB and MSSQL Instance. When the object_type is `mssql_instance` the `mssql_host` keyword argument is now required. When the `object_type` is `mssql_db`, both the `mssql_instance` the `mssql_host` keyword arguments are required. 
 - Added all examples to the `object_id()` documentation.
 - Prevent an error from being thrown when passing in an integer value into the `params` keyword argument in the `get()` function ([Issue 239](https://github.com/rubrikinc/rubrik-sdk-for-python/issues/236))
+- Fix MSSQL Recovery Point timestamp validation on Windows OS Python 2 & 3 ([Issue 268](https://github.com/rubrikinc/rubrik-sdk-for-python/issues/268))
 
 ## v2.0.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - **Fixed** for any bug fixes.
 - **Security** in case of vulnerabilities.
 
+## Unreleased
+
+### Added
+
+### Changed
+
+### Fixed
+- Fix MSSQL Recovery Point timestamp validation on Windows OS Python 2 & 3 ([Issue 268](https://github.com/rubrikinc/rubrik-sdk-for-python/issues/268))
+
 ## v2.0.10
 
-## Added
+### Added
 
 - `get_sla_objects()` now also supports the following object types: hyper-v, mssql_db, ec2_instance, oracle_db, vcd, managed_volume, ahv, nas_share, linux_and_unix_host, windows_host ([Issue 226](https://github.com/rubrikinc/rubrik-sdk-for-python/issues/226))
 - `object_id()` now supports the `organization`, `organization_role_id`, `organization_admin_role`, and `mssql_availability_group` `object_type`
@@ -24,17 +33,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `add_organization_protectable_object_sql_server_db()` ([Issue 234](https://github.com/rubrikinc/rubrik-sdk-for-python/issues/234))
 - Added `add_organization_protectable_object_sql_server_availability_group()` ([Issue 234](https://github.com/rubrikinc/rubrik-sdk-for-python/issues/234))
 
-## Changed
+### Changed
 
 - The `create_sla()` function will return a more clear error message when the SLA was found on the Rubrik cluster but with a different configuraiton than the one provided. ([Issue 236](https://github.com/rubrikinc/rubrik-sdk-for-python/issues/236))
 
-## Fixed
+### Fixed
 
 - When calling create_sla() an error will not longer be thrown for frequencies and retentions that have a default None value provided ([Issue 232](https://github.com/rubrikinc/rubrik-sdk-for-python/issues/232))
 - The `object_id()` function now returns the correct the MSSQL DB and MSSQL Instance. When the object_type is `mssql_instance` the `mssql_host` keyword argument is now required. When the `object_type` is `mssql_db`, both the `mssql_instance` the `mssql_host` keyword arguments are required. 
 - Added all examples to the `object_id()` documentation.
 - Prevent an error from being thrown when passing in an integer value into the `params` keyword argument in the `get()` function ([Issue 239](https://github.com/rubrikinc/rubrik-sdk-for-python/issues/236))
-- Fix MSSQL Recovery Point timestamp validation on Windows OS Python 2 & 3 ([Issue 268](https://github.com/rubrikinc/rubrik-sdk-for-python/issues/268))
 
 ## v2.0.9
 

--- a/rubrik_cdm/data_management.py
+++ b/rubrik_cdm/data_management.py
@@ -2088,7 +2088,8 @@ class Data_Management(Api):
         Returns:
             dict -- A dictionary with values {'is_recovery_point': bool, 'recovery_timestamp': datetime}.
         """
-
+        epoch = datetime(1970,1,1,0,0,0)
+        
         if self.function_name == "":
             self.function_name = inspect.currentframe().f_code.co_name
 
@@ -2113,7 +2114,7 @@ class Data_Management(Api):
             recovery_date_time = datetime.strptime(
                 recovery_date_time, '%Y-%m-%dT%H:%M')
             # Create recovery timestamp in (ms) as integer from datetime object
-            recovery_timestamp = int(recovery_date_time.strftime('%s')) * 1000
+            recovery_timestamp = (recovery_date_time - epoch).total_seconds() * 1000
             is_recovery_point = True
         else:
             self.log(
@@ -2129,7 +2130,7 @@ class Data_Management(Api):
             recovery_date_time = datetime.strptime(
                 recovery_date_time, '%Y-%m-%dT%H:%M')
             # Create recovery timestamp in (ms) as integer from datetime object
-            recovery_timestamp = int(recovery_date_time.strftime('%s')) * 1000
+            recovery_timestamp = (recovery_date_time - epoch).total_seconds() * 1000
 
             for range in range_summary['data']:
                 start_str, end_str = [range['beginTime'], range['endTime']]


### PR DESCRIPTION
# Description

On Windows OS with Python 2/3, strftime %s is throwing ValueError when creating MSSQL recovery_timestamp. Change method to manually calculate seconds since epoch.

## Related Issue

https://github.com/rubrikinc/rubrik-sdk-for-python/issues/268

## Motivation and Context

Bugfix

## How Has This Been Tested?

* Ubuntu 20.04 - Python 2/3 saw no issues before/after the changes.
* Windows Server 2019 - Python 2/3 saw `ValueError` prior to changes. After changes, was able to Export MSSQL Database.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/rubrik-sdk-for-python/blob/master/CONTRIBUTING.md)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
