### PR TITLE
Add missing resouceGroupId for Azure CloudOn

### DIFF
--- a/rubrik_cdm/cloud.py
+++ b/rubrik_cdm/cloud.py
@@ -378,7 +378,7 @@ class Cloud(Api):
         self.log("azure_cloudout: Creating the Azure archive location.")
         return self.post('internal', '/archive/object_store', config)
 
-    def azure_cloudon(self, archive_name, container, storage_account_name, application_id, application_key, tenant_id, region, virtual_network_id, subnet_name, security_group_id, timeout=30):  # pylint: ignore
+    def azure_cloudon(self, archive_name, container, storage_account_name, application_id, application_key, tenant_id, region, resource_group, virtual_network_id, subnet_name, security_group_id, timeout=30):  # pylint: ignore
         """Enable CloudOn for an existing Azure archival location.
 
         Arguments:
@@ -389,6 +389,7 @@ class Cloud(Api):
             application_key {str} -- The key of the application registered in Azure Active Directory.
             tenant_id {str} -- The tenant ID, also known as the directory ID, found under the Azure Active Directory properties.
             region {str} -- The name of the Azure region where the `container` is located. (choices: {westus, westus2, centralus, eastus, eastus2, northcentralus, southcentralus, westcentralus, canadacentral, canadaeast, brazilsouth, northeurope, westeurope, uksouth, ukwest, eastasia, southeastasia, japaneast, japanwest, australiaeast australiasoutheast, centralindia, southindia, westindia, koreacentral, koreasouth})
+            resource_group {str} -- The Azure resource group used by Rubrik cluster to launch a temporary Rubrik instance in Azure for instantiation.
             virtual_network_id {str} -- The Azure virtual network ID used by Rubrik cluster to launch a temporary Rubrik instance in Azure for instantiation.
             subnet_name {str} -- The Azure subnet name used by Rubrik cluster to launch a temporary Rubrik instance in Azure for instantiation.
             security_group_id {str} -- The Azure Security Group ID used by Rubrik cluster to launch a temporary Rubrik instance in Azure for instantiation.
@@ -439,7 +440,7 @@ class Cloud(Api):
 
         config = {}
         config['name'] = archive_name
-        config['objectStoreType'] = 'Azure'
+        # config['objectStoreType'] = 'Azure'
         config['isComputeEnabled'] = True
 
         config['azureComputeSummary'] = {}
@@ -449,6 +450,7 @@ class Cloud(Api):
         config['azureComputeSummary']["region"] = region
         config['azureComputeSummary']["generalPurposeStorageAccountName"] = storage_account_name
         config['azureComputeSummary']["containerName"] = container
+        config['azureComputeSummary']["environment"] = 'AZURE'
 
         config['azureComputeSecret'] = {}
         config['azureComputeSecret']["clientSecret"] = application_key
@@ -456,6 +458,7 @@ class Cloud(Api):
         config['defaultComputeNetworkConfig']['subnetId'] = subnet_name
         config['defaultComputeNetworkConfig']['vNetId'] = virtual_network_id
         config['defaultComputeNetworkConfig']['securityGroupId'] = security_group_id
+        config['defaultComputeNetworkConfig']['resourceGroupId'] = resource_group
 
         redacted_archive_definition = {}
         redacted_archive_definition['name'] = archive_name

--- a/tests/unit/cloud_test.py
+++ b/tests/unit/cloud_test.py
@@ -700,6 +700,7 @@ def test_azure_cloudon_idempotence(rubrik, mocker):
         "application_key",
         "tenant_id",
         "westus",
+        "resource_group"
         "/subscriptions/89b90dec-a6e1-4q9e-bc12-23138bb3cee4/resourceGroups/PythonSDK/providers/Microsoft.Network/virtualNetworks/pythonsdk",
         "subnet_name",
         "security_group_id") == "No change required. The 'archive_name' archival location is already configured for CloudOn."

--- a/tests/unit/cloud_test.py
+++ b/tests/unit/cloud_test.py
@@ -640,6 +640,7 @@ def test_azure_cloudon_invalid_region(rubrik):
             "application_key",
             "tenant_id",
             "not_a_valid_region",
+            "resource_group",
             "virtual_network_id",
             "subnet_name",
             "security_group_id")
@@ -700,7 +701,7 @@ def test_azure_cloudon_idempotence(rubrik, mocker):
         "application_key",
         "tenant_id",
         "westus",
-        "resource_group"
+        "resource_group",
         "/subscriptions/89b90dec-a6e1-4q9e-bc12-23138bb3cee4/resourceGroups/PythonSDK/providers/Microsoft.Network/virtualNetworks/pythonsdk",
         "subnet_name",
         "security_group_id") == "No change required. The 'archive_name' archival location is already configured for CloudOn."


### PR DESCRIPTION
# Description

Fix Azure CloudOn api failure.

## Related Issue

Azure CloudOn api might have changed on 5.3. 

## How Has This Been Tested?

Run azure_cloudon.py on 5.3.0 CDM cluster

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/rubrik-sdk-for-python/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
