### PR TITLE
Sql tz fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 ### Fixed
+- Fix time zone issue when using latest for time/date on sql operations ([Issue 274](https://github.com/rubrikinc/rubrik-sdk-for-python/issues/274))
+- Fix time granularity issue for sql exports ([Issue 278](https://github.com/rubrikinc/rubrik-sdk-for-python/issues/278))
 - Fix MSSQL Recovery Point timestamp validation on Windows OS Python 2 & 3 ([Issue 268](https://github.com/rubrikinc/rubrik-sdk-for-python/issues/268))
 
 ## v2.0.10

--- a/docs/_build/sql_db_export.md
+++ b/docs/_build/sql_db_export.md
@@ -12,7 +12,7 @@ def sql_db_export(self, db_name, date, time, sql_instance=None, sql_host=None, t
 |-------------|------|-----------------------------------------------------------------------------|---------|
 | db_name  | str | The name of the database to be exported. |  |
 | date  | str | The recovery_point date formated as 'Month-Date-Year' (ex: 8-9-2018). |  |
-| time  | str | The recovery_point time formated as `Hour:Minute` (ex: 3:30 AM). |  |
+| time  | str | The recovery_point time formated as `Hour:Minute:Second` (ex: 3:30:01 AM). |  |
 
 ## Keyword Arguments
 
@@ -48,7 +48,7 @@ rubrik = rubrik_cdm.Connect()
 
 db_name = "python-sdk-demo"
 date = '10-21-2019'
-time = '3:00 PM'
+time = '3:00:00 PM'
 sql_instance = 'MSSQLSERVER'
 sql_host = 'sql.rubrikdemo.com'
 target_instance_name = sql_instance

--- a/docs/_build/sql_instant_recovery.md
+++ b/docs/_build/sql_instant_recovery.md
@@ -12,7 +12,7 @@ def sql_instant_recovery(self, db_name, date, time, sql_instance=None, sql_host=
 |-------------|------|-----------------------------------------------------------------------------|---------|
 | db_name  | str | The name of the database to instantly recover. |  |
 | date  | str | The recovery_point date to recover to formated as `Month-Day-Year` (ex: 1-15-2014). |  |
-| time  | str | The recovery_point time to recover to formated as `Hour:Minute AM/PM` (ex: 1:30 AM). |  |
+| time  | str | The recovery_point time to recover to formated as `Hour:Minute:Second AM/PM` (ex: 1:30 AM). |  |
 
 ## Keyword Arguments
 
@@ -41,7 +41,7 @@ rubrik = rubrik_cdm.Connect()
 
 db_name = "python-sdk-demo"
 date = "08-26-2018"
-time = "12:11 AM"
+time = "12:11:00 AM"
 sql_instance = 'MSSQLSERVER'
 sql_host = 'sql.rubrikdemo.com'
 mount_name = 'AdventureWorksClone'

--- a/rubrik_cdm/data_management.py
+++ b/rubrik_cdm/data_management.py
@@ -1000,7 +1000,7 @@ class Data_Management(Api):
             vm_name {str} -- The name of the vSphere VM to Live Mount.
         Keyword Arguments:
             date {str} -- The date of the snapshot you wish to Live Mount formated as `Month-Day-Year` (ex: 1-15-2014). If `latest` is specified, the last snapshot taken will be used. (default: {'latest'})
-            time {str} -- The time of the snapshot you wish to Live Mount formated as `Hour:Minute AM/PM` (ex: 1:30 AM). If `latest` is specified, the last snapshot taken will be used. (default: {'latest'})
+            time {str} -- The time of the snapshot you wish to Live Mount formated as `Hour:Minute:Second AM/PM` (ex: 1:30:01 AM). If `latest` is specified, the last snapshot taken will be used. (default: {'latest'})
             host {str} -- The hostname or IP address of the ESXi host to Live Mount the VM on. By default, the current host will be used. (default: {'current'})
             remove_network_devices {bool} -- Flag that determines whether to remove the network interfaces from the Live Mounted VM. Set to `True` to remove all network interfaces. (default: {False})
             power_on {bool} -- Flag that determines whether the VM should be powered on after the Live Mount. Set to `True` to power on the VM. Set to `False` to mount the VM but not power it on. (default: {True})
@@ -1078,7 +1078,7 @@ class Data_Management(Api):
             vm_name {str} -- The name of the VM to Instantly Recover.
         Keyword Arguments:
             date {str} -- The date of the snapshot you wish to Instantly Recover formated as `Month-Day-Year` (ex: 1-15-2014). If 'latest' is specified, the last snapshot taken will used. (default: {'latest'})
-            time {str} -- The time of the snapshot you wish to Instantly Recover formated as `Hour:Minute AM/PM`  (ex: 1:30 AM). If 'latest' is specified, the last snapshot taken will be used. (default: {'latest'})
+            time {str} -- The time of the snapshot you wish to Instantly Recover formated as `Hour:Minute:Second AM/PM`  (ex: 1:30:01 AM). If 'latest' is specified, the last snapshot taken will be used. (default: {'latest'})
             host {str} -- The hostname or IP address of the ESXi host to Instantly Recover the VM on. By default, the current host will be used. (default: {'current'})
             remove_network_devices {bool} -- Flag that determines whether to remove the network interfaces from the Instantly Recovered VM. Set to `True` to remove all network interfaces. (default: {False})
             power_on {bool} -- Flag that determines whether the VM should be powered on after Instant Recovery. Set to `True` to power on the VM. Set to `False` to instantly recover the VM but not power it on. (default: {True})
@@ -1172,7 +1172,7 @@ class Data_Management(Api):
         conversion process.
         Arguments:
             date {str} -- A date value formated as `Month-Day-Year` (ex: 1/15/2014).
-            time {str} -- A time value formated as `Hour:Minute AM/PM` (ex: 1:30 AM).
+            time {str} -- A time value formated as `Hour:Minute:Second AM/PM` (ex: 1:30:01 AM).
         Returns:
             str -- A combined date/time value formated as `Year-Month-DayTHour:Minute` where Hour:Minute is on the 24-hour clock (ex : 2014-1-15T01:30).
         """
@@ -1191,10 +1191,10 @@ class Data_Management(Api):
                 "The date argument '{}' must be formatd as 'Month-Date-Year' (ex: 8-9-2018).".format(date))
         # Validate the Time formating
         try:
-            snapshot_time = datetime.strptime(time, '%I:%M %p')
+            snapshot_time = datetime.strptime(time, '%I:%M:%S %p')
         except ValueError:
             raise InvalidParameterException(
-                "The time argument '{}' must be formatd as 'Hour:Minute AM/PM' (ex: 2:57 AM).".format(time))
+                "The time argument '{}' must be formatd as 'Hour:Minute:Second AM/PM' (ex: 2:57:01 AM).".format(time))
 
         self.log("_date_time_conversion: Getting the Rubrik cluster timezone.")
         cluster_summary = self.get('v1', '/cluster/me', timeout=timeout)
@@ -1202,11 +1202,11 @@ class Data_Management(Api):
 
         self.log(
             "_date_time_conversion: Converting the provided time to the 24-hour clock.")
-        snapshot_time_24_hour_clock = datetime.strftime(snapshot_time, "%H:%M")
+        snapshot_time_24_hour_clock = datetime.strftime(snapshot_time, "%H:%M:%S")
 
         self.log("_date_time_conversion: Creating a combined date/time variable.")
         snapshot_datetime = datetime.strptime('{} {}'.format(
-            date, snapshot_time_24_hour_clock), '%m-%d-%Y %H:%M')
+            date, snapshot_time_24_hour_clock), '%m-%d-%Y %H:%M:%S')
 
         # Add Timezone to snapshot_datetime Variable
         timezone = pytz.timezone(cluster_timezone)
@@ -1216,7 +1216,7 @@ class Data_Management(Api):
         utc_timezone = pytz.UTC
         snapshot_datetime = snapshot_datetime.astimezone(utc_timezone)
 
-        return snapshot_datetime.strftime('%Y-%m-%dT%H:%M')
+        return snapshot_datetime.strftime('%Y-%m-%dT%H:%M:%S')
 
     def pause_snapshots(self, object_name, object_type, timeout=180):
         """Pause all snapshot activity for the provided object.
@@ -1831,7 +1831,7 @@ class Data_Management(Api):
             mount_name {str} -- The name given to the Live Mounted database i.e. AdventureWorks_Clone.
         Keyword Arguments:
             date {str} -- The recovery_point date to recovery to formated as `Month-Day-Year` (ex: 1-15-2014). If `latest` is specified, the last snapshot taken will be used. (default: {'latest'})
-            time {str} -- The recovery_point time to recovery to formated as `Hour:Minute AM/PM` (ex: 1:30 AM). If `latest` is specified, the last snapshot taken will be used. (default: {'latest'})
+            time {str} -- The recovery_point time to recovery to formated as `Hour:Minute:Second AM/PM` (ex: 1:30:01 AM). If `latest` is specified, the last snapshot taken will be used. (default: {'latest'})
             timeout {int} -- The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. (default: {30})
         Returns:
             dict -- The full response of `POST /v1/mssql/db/{id}/mount`.
@@ -2082,13 +2082,12 @@ class Data_Management(Api):
         Arguments:
             mssql_id {str} -- The ID of the database.
             date {str} -- The recovery_point date formated as `Month-Day-Year` (ex: 1-15-2014).
-            time {str} -- The recovery_point time  formated as `Hour:Minute AM/PM` (ex: 1:30 AM).
+            time {str} -- The recovery_point time  formated as `Hour:Minute:Second AM/PM` (ex: 1:30:01 AM).
         Keyword Arguments:
             timeout {int} -- The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error. (default: {30})
         Returns:
             dict -- A dictionary with values {'is_recovery_point': bool, 'recovery_timestamp': datetime}.
         """
-        epoch = datetime(1970,1,1,0,0,0)
         
         if self.function_name == "":
             self.function_name = inspect.currentframe().f_code.co_name
@@ -2104,8 +2103,8 @@ class Data_Management(Api):
                     "The database with ID {} does not have any existing snapshots.".format(mssql_id))
             # Parsing latest snapshot time string value to a datetime object as YYYY-MM-DDTHH:MM
             recovery_date_time = datetime.strptime(
-                latest_date_time[:16], '%Y-%m-%dT%H:%M:%S.%f')
-            # Create recovery timestamp in (ms) as integer from datetime object
+                latest_date_time[:19], '%Y-%m-%dT%H:%M:%S')
+            # Create recovery timestamp in ISO8601 format from datetime object
             recovery_timestamp = recovery_date_time.isoformat(timespec='milliseconds')
             is_recovery_point = True
         else:
@@ -2120,15 +2119,15 @@ class Data_Management(Api):
             recovery_date_time = self._date_time_conversion(date, time)
             # Parse to datetime object
             recovery_date_time = datetime.strptime(
-                recovery_date_time, '%Y-%m-%dT%H:%M')
-            # Create recovery timestamp in (ms) as integer from datetime object
-            recovery_timestamp = (recovery_date_time - epoch).total_seconds() * 1000
+                recovery_date_time, '%Y-%m-%dT%H:%M:%S')
+            # Create recovery timestamp in ISO8601 format from datetime object
+            recovery_timestamp = recovery_date_time.isoformat(timespec='milliseconds')
 
             for range in range_summary['data']:
                 start_str, end_str = [range['beginTime'], range['endTime']]
                 # Parsing the range beginTime and endTime values to a datetime object as YYYY-MM-DDTHH:MM
-                start, end = [datetime.strptime(start_str[:16], '%Y-%m-%dT%H:%M'),
-                              datetime.strptime(end_str[:16], '%Y-%m-%dT%H:%M')]
+                start, end = [datetime.strptime(start_str[:19], '%Y-%m-%dT%H:%M:%S'),
+                              datetime.strptime(end_str[:19], '%Y-%m-%dT%H:%M:%S')]
 
                 self.log(
                     "_validate_sql_recovery_point: Searching for the provided recovery_point.")
@@ -2149,7 +2148,7 @@ class Data_Management(Api):
         Arguments:
             db_name {str} -- The name of the database to instantly recover.
             date {str} -- The recovery_point date to recover to formated as `Month-Day-Year` (ex: 1-15-2014).
-            time {str} -- The recovery_point time to recover to formated as `Hour:Minute AM/PM` (ex: 1:30 AM).
+            time {str} -- The recovery_point time to recover to formated as `Hour:Minute:Second AM/PM` (ex: 1:30:01 AM).
         Keyword Arguments:
             sql_instance {str} -- The SQL instance name with the database to instantly recover.
             sql_host {str} -- The SQL Host of the database/instance to instantly recover.
@@ -2490,7 +2489,7 @@ class Data_Management(Api):
         Arguments:
             db_name {str} -- The name of the database.
             date {str} -- The recovery_point date formated as 'Month-Date-Year' (ex: 8-9-2018).
-            time {str} -- The recovery_point time formated as `Hour:Minute` (ex: 3:30 AM).
+            time {str} -- The recovery_point time formated as `Hour:Minute:Second` (ex: 3:30:01 AM).
         Keyword Arguments:
             sql_instance {str} -- The SQL instance name with the database.
             sql_host {str} -- The SQL Host of the database/instance.
@@ -2506,7 +2505,7 @@ class Data_Management(Api):
 
         recovery_date_time = self._date_time_conversion(date, time)
         recovery_point = datetime.strptime(
-            recovery_date_time, '%Y-%m-%dT%H:%M').isoformat()
+            recovery_date_time, '%Y-%m-%dT%H:%M:%S').isoformat()
         valid_recovery_point = self._validate_sql_recovery_point(
             mssql_id, date, time)
 
@@ -2530,7 +2529,7 @@ class Data_Management(Api):
         Arguments:
             db_name {str} -- The name of the database to be exported.
             date {str} -- The recovery_point date formated as 'Month-Date-Year' (ex: 8-9-2018).
-            time {str} -- The recovery_point time formated as `Hour:Minute` (ex: 3:30 AM).
+            time {str} -- The recovery_point time formated as `Hour:Minute:Second` (ex: 3:30:01 AM).
         Keyword Arguments:
             sql_instance {str} -- The SQL instance name with the database to be exported.
             sql_host {str} -- The SQL Host of the database/instance to be exported.

--- a/rubrik_cdm/data_management.py
+++ b/rubrik_cdm/data_management.py
@@ -1174,7 +1174,7 @@ class Data_Management(Api):
             date {str} -- A date value formated as `Month-Day-Year` (ex: 1/15/2014).
             time {str} -- A time value formated as `Hour:Minute:Second AM/PM` (ex: 1:30:01 AM).
         Returns:
-            str -- A combined date/time value formated as `Year-Month-DayTHour:Minute` where Hour:Minute is on the 24-hour clock (ex : 2014-1-15T01:30).
+            str -- A combined date/time value formated as `Year-Month-DayTHour:Minute:Second` where Hour:Minute:Second is on the 24-hour clock (ex : 2014-1-15T01:30:01).
         """
 
         if self.function_name == "":

--- a/rubrik_cdm/data_management.py
+++ b/rubrik_cdm/data_management.py
@@ -2101,7 +2101,7 @@ class Data_Management(Api):
             except:
                 raise InvalidParameterException(
                     "The database with ID {} does not have any existing snapshots.".format(mssql_id))
-            # Parsing latest snapshot time string value to a datetime object as YYYY-MM-DDTHH:MM
+            # Parsing latest snapshot time string value to a datetime object as YYYY-MM-DDTHH:MM:SS
             recovery_date_time = datetime.strptime(
                 latest_date_time[:19], '%Y-%m-%dT%H:%M:%S')
             # Create recovery timestamp in ISO8601 format from datetime object
@@ -2125,7 +2125,7 @@ class Data_Management(Api):
 
             for range in range_summary['data']:
                 start_str, end_str = [range['beginTime'], range['endTime']]
-                # Parsing the range beginTime and endTime values to a datetime object as YYYY-MM-DDTHH:MM
+                # Parsing the range beginTime and endTime values to a datetime object as YYYY-MM-DDTHH:MM:SS
                 start, end = [datetime.strptime(start_str[:19], '%Y-%m-%dT%H:%M:%S'),
                               datetime.strptime(end_str[:19], '%Y-%m-%dT%H:%M:%S')]
 

--- a/rubrik_cdm/data_management.py
+++ b/rubrik_cdm/data_management.py
@@ -1037,7 +1037,7 @@ class Data_Management(Api):
             self.log(
                 "vsphere_live_mount: Converting the provided date/time into UTC.")
             snapshot_date_time = self._date_time_conversion(date, time)
-            print(f'LOOOOOOOK: {snapshot_date_time}')
+
             current_snapshots = {}
 
             for snapshot in vm_summary['snapshots']:

--- a/rubrik_cdm/data_management.py
+++ b/rubrik_cdm/data_management.py
@@ -2103,16 +2103,8 @@ class Data_Management(Api):
                 raise InvalidParameterException(
                     "The database with ID {} does not have any existing snapshots.".format(mssql_id))
             # Parsing latest snapshot time string value to a datetime object as YYYY-MM-DDTHH:MM
-            data_str = datetime.strptime(
-                latest_date_time[:16], '%Y-%m-%dT%H:%M')
-            # Create date & time strings from datetime object as MM-DD-YYYY & HH:MM AM/PM
-            date_str, time_str = [data_str.strftime(
-                '%m-%d-%Y'), data_str.strftime('%I:%M %p')]
-            # Convert the date & time to cluster timezone, see _date_time_conversion function for details
-            recovery_date_time = self._date_time_conversion(date_str, time_str)
-            # Parse again to datetime object
             recovery_date_time = datetime.strptime(
-                recovery_date_time, '%Y-%m-%dT%H:%M')
+                latest_date_time[:16], '%Y-%m-%dT%H:%M')
             # Create recovery timestamp in (ms) as integer from datetime object
             recovery_timestamp = (recovery_date_time - epoch).total_seconds() * 1000
             is_recovery_point = True

--- a/rubrik_cdm/data_management.py
+++ b/rubrik_cdm/data_management.py
@@ -2691,3 +2691,4 @@ class Data_Management(Api):
 
         self.log('register_vm: Registering the RBS agent.')
         return self.post('v1', '/vmware/vm/{}/register_agent'.format(vm_id), {}, timeout=timeout)
+        

--- a/rubrik_cdm/data_management.py
+++ b/rubrik_cdm/data_management.py
@@ -2104,9 +2104,9 @@ class Data_Management(Api):
                     "The database with ID {} does not have any existing snapshots.".format(mssql_id))
             # Parsing latest snapshot time string value to a datetime object as YYYY-MM-DDTHH:MM
             recovery_date_time = datetime.strptime(
-                latest_date_time[:16], '%Y-%m-%dT%H:%M')
+                latest_date_time[:16], '%Y-%m-%dT%H:%M:%S.%f')
             # Create recovery timestamp in (ms) as integer from datetime object
-            recovery_timestamp = (recovery_date_time - epoch).total_seconds() * 1000
+            recovery_timestamp = recovery_date_time.isoformat(timespec='milliseconds')
             is_recovery_point = True
         else:
             self.log(
@@ -2585,7 +2585,7 @@ class Data_Management(Api):
         else:
             config = {}
             config['recoveryPoint'] = {
-                'timestampMs': recovery_point['recovery_timestamp']}
+                'date': recovery_point['recovery_timestamp']}
             config['targetInstanceId'] = target_instance_id
             config['targetDatabaseName'] = target_database_name
             if target_file_paths is not None:


### PR DESCRIPTION
# Description

This pull request addresses issues regarding _validate_sql_recovery_point and _date_time_conversion:

-  SQL recoveries don't allow seconds when specifying time, causing a failure every time an export has a non-zero value for seconds. This pull request adds seconds to _validate_sql_recovery_point and _date_time_conversion to work for SQL functions without breaking vSphere functionality. 
-  _validate_sql_recovery_point converts for time zone unnecessarily when specifying "latest" which breaks automation if run on a different time zone then the Rubrik Cluster.

## Related Issue

SQL export seconds issue: https://github.com/rubrikinc/rubrik-sdk-for-python/issues/274
Time zone Issue: https://github.com/rubrikinc/rubrik-sdk-for-python/issues/278

## Motivation and Context

This change fixes sql_db_export during these 2 scenarios:

1. The function is ran from a client on a different time zone then the Rubrik Cluster.
2. The export targeted has a non-zero second for time.

## How Has This Been Tested?

This has been tested on a Rubrik Cluster running 5.3.2-p3-19174. 

The following functions have been tested due to being modified directly or having a sub-function modified:
- sql_instant_recovery
- get_sql_db_files
- vsphere_live_mount
- vsphere_instant_recovery

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/rubrik-sdk-for-python/blob/master/CONTRIBUTING.md)** document.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.