### PR TITLE
update changed api endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Fix MSSQL Recovery Point timestamp validation on Windows OS Python 2 & 3 ([Issue 268](https://github.com/rubrikinc/rubrik-sdk-for-python/issues/268))
+- Fix Undefined API when calling volume_group/hosts apis ([Issue 286](https://github.com/rubrikinc/rubrik-sdk-for-python/issues/286))
 
 ## v2.0.10
 

--- a/rubrik_cdm/data_management.py
+++ b/rubrik_cdm/data_management.py
@@ -440,7 +440,7 @@ class Data_Management(Api):
                 "api_endpoint": "/oracle/hierarchy/root/children?name={}".format(object_name)
             },
             "volume_group": {
-                "api_version": "internal",
+                "api_version": "v1",
                 "api_endpoint": "/volume_group?is_relic=false"
             },
             "archival_location": {
@@ -940,7 +940,7 @@ class Data_Management(Api):
             self.log("assign_sla: Getting a list of all volumes on the '{}' Windows host.".format(
                 windows_host))
             host_volumes = self.get(
-                "internal", "/host/{}/volume".format(physical_host_id), timeout=timeout)
+                "v1", "/host/{}/volume".format(physical_host_id), timeout=timeout)
 
             # If the object_name (volumes to assign to the SLA) is a string, create a list for processing
             if not isinstance(object_name, list):
@@ -966,7 +966,7 @@ class Data_Management(Api):
             self.log(
                 "assign_sla: Getting details of the current volume group on the Windows host.")
             volume_group_details = self.get(
-                "internal", "/volume_group/{}".format(volume_group_id), timeout=timeout)
+                "v1", "/volume_group/{}".format(volume_group_id), timeout=timeout)
 
             # Create a config of the current volume sla settings
             current_volumes_included_in_snapshot = []
@@ -992,7 +992,7 @@ class Data_Management(Api):
             else:
                 self.log("assign_sla: Assigning the vSphere VM '{}' to the '{}' SLA Domain.".format(
                     object_name, sla_name))
-                return self.patch("internal", "/volume_group/{}".format(volume_group_id), config, timeout=timeout)
+                return self.patch("v1", "/volume_group/{}".format(volume_group_id), config, timeout=timeout)
 
     def vsphere_live_mount(self, vm_name, date='latest', time='latest', host='current', remove_network_devices=False, power_on=True, timeout=15):  # pylint: ignore
         """Live Mount a vSphere VM from a specified snapshot. If a specific date and time is not provided, the last snapshot taken will be used.


### PR DESCRIPTION
# Description

Update moved api endpoints to their new locations

## Related Issue

This project only accepts pull requests related to open issues.

* If suggesting a new feature or change, please discuss it in an issue first.
* If fixing a bug, there should be an issue describing it with steps to reproduce

https://github.com/rubrikinc/rubrik-sdk-for-python/issues/286

## Motivation and Context

The endpoints have changed at some point

## How Has This Been Tested?

By running below code the ansible module that uses this library was able to complete without errors. 

```
  - name: Assign volume group SLA to host [Windows]
    rubrikinc.cdm.rubrik_assign_sla:
      username: "{{ rubrik_username }}"
      password: "{{ rubrik_password }}"
      node_ip: "{{ dataprotection_cluster[0] }}"
      object_name: "{{ drive_letters }}"
      sla_name: "{{ dataprotection_sladomain[0] }}"
      object_type: volume_group
      windows_host: "{{ host_backup_fqdn }}"
    delegate_to: 127.0.0.1
```

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/rubrik-sdk-for-python/blob/master/CONTRIBUTING.md)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
